### PR TITLE
✨ [FEAT] 이력서 등록 기능 구현 (#11) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.h2database:h2'
+	testImplementation 'org.projectlombok:lombok:1.18.28'
 	compileOnly 'org.projectlombok:lombok'
+	compileOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/devcv/common/config/S3Config.java
+++ b/src/main/java/com/devcv/common/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.devcv.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.amazonaws.services.s3.AmazonS3;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+
+
+
+}

--- a/src/main/java/com/devcv/common/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/common/config/SpringSecurityConfig.java
@@ -1,0 +1,24 @@
+package com.devcv.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SpringSecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .cors().and().headers().frameOptions().disable()
+                .and()
+                .authorizeHttpRequests()
+                .requestMatchers("/","/h2-console/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .httpBasic();
+        return http.build();
+    }
+}

--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
     //400
+    EMPTY_FILE_EXCEPTION("입력받은 이미지 파일이 빈 파일입니다."),
+    NO_FILE_EXTENTION("파일 확장자가 없습니다."),
+    INVALID_FILE_EXTENTION("유효하지 않은 파일 확장자입니다."),
 
     //401
 
@@ -13,6 +16,8 @@ public enum ErrorCode {
     //404
 
     //500
+    IO_EXCEPTION_ON_IMAGE_UPLOAD("이미지 업로드 중 IO 예외가 발생했습니다."),
+    PUT_OBJECT_EXCEPTION("S3에 객체를 저장하는 중 예외가 발생했습니다."),
     INTERNAL_SERVER_ERROR("서버 내부에 문제가 발생했습니다."),
     TEST_ERROR("테스트용 에러입니다."),
     ;

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.devcv.common.exception;
 
 import com.devcv.common.exception.dto.ErrorResponse;
+import com.devcv.common.util.exception.S3Exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,5 +26,30 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.from(ErrorCode.TEST_ERROR));
+    }
+
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<ErrorResponse>handle(S3Exception e) {
+        System.out.println("s3 upload error");
+        log.error(e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+        HttpStatus status;
+
+        switch (errorCode) {
+            case EMPTY_FILE_EXCEPTION:
+            case NO_FILE_EXTENTION:
+            case INVALID_FILE_EXTENTION:
+                status = HttpStatus.BAD_REQUEST;
+                break;
+            case IO_EXCEPTION_ON_IMAGE_UPLOAD:
+            case PUT_OBJECT_EXCEPTION:
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+                break;
+            default:
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return ResponseEntity.status(status)
+                .body(ErrorResponse.from(errorCode));
     }
 }

--- a/src/main/java/com/devcv/common/util/S3Uploader.java
+++ b/src/main/java/com/devcv/common/util/S3Uploader.java
@@ -1,0 +1,100 @@
+package com.devcv.common.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.devcv.common.exception.ErrorCode;
+import com.devcv.common.util.exception.S3Exception;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    //외부 호출 가능 메서드
+    public String upload(MultipartFile image) {
+        //입력받은 이미지 파일이 빈 파일인지 검증
+        if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())){
+            throw new S3Exception(ErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        //uploadImage 호출
+        return this.uploadImage(image);
+    }
+
+
+    private String uploadImage(MultipartFile image) {
+        // validateImageFileExtention() 호출
+        this.validateImageFileExtension(image.getOriginalFilename());
+        try {
+            //uploadImageToS3() 호출
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+        }
+    }
+    // 확장자 검사
+    private void validateImageFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new S3Exception(ErrorCode.NO_FILE_EXTENTION);
+        }
+        // filename을 받아서 파일 확장자가 jpg, jpeg, png, gif, pdf, hwp, docx 중에 속하는지 검증한다.
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtensionList = Arrays.asList("jpg", "jpeg", "png", "gif", "pdf", "hwp", "docx");
+
+        if (!allowedExtensionList.contains(extension)) {
+            throw new S3Exception(ErrorCode.INVALID_FILE_EXTENTION);
+        }
+    }
+
+    // S3에 이미지 업로드 메서드, public url 반환
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename(); // 원본 파일 명
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".")); // 확장자 명
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; // 변경된 파일 명
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(image.getContentType());
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata);
+            amazonS3.putObject(putObjectRequest); // S3 putObject 정책 실행
+        } catch (Exception e) {
+            log.error("Error putting object to S3", e);
+            throw new S3Exception(ErrorCode.PUT_OBJECT_EXCEPTION);
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        // 최종 url 반환
+        return  amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+}

--- a/src/main/java/com/devcv/common/util/exception/S3Exception.java
+++ b/src/main/java/com/devcv/common/util/exception/S3Exception.java
@@ -1,0 +1,12 @@
+package com.devcv.common.util.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class S3Exception extends CustomException {
+
+    public S3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/devcv/register/application/ResumeImageMapper.java
+++ b/src/main/java/com/devcv/register/application/ResumeImageMapper.java
@@ -1,0 +1,21 @@
+package com.devcv.register.application;
+
+import com.devcv.register.domain.ResumeImage;
+import com.devcv.register.domain.dto.ResumeImageDTO;
+
+public class ResumeImageMapper {
+
+    public static ResumeImage dtoToEntity(ResumeImageDTO resumeImageDTO) {
+        return ResumeImage.builder()
+                .resumeImgPath(resumeImageDTO.getResumeImgPath())
+                .ord(resumeImageDTO.getOrd())
+                .build();
+    }
+
+    public static ResumeImageDTO entityToDto(ResumeImage resumeImage) {
+        return ResumeImageDTO.builder()
+                .resumeImgPath(resumeImage.getResumeImgPath())
+                .ord(resumeImage.getOrd())
+                .build();
+    }
+}

--- a/src/main/java/com/devcv/register/application/ResumeMapper.java
+++ b/src/main/java/com/devcv/register/application/ResumeMapper.java
@@ -1,0 +1,63 @@
+package com.devcv.register.application;
+
+import com.devcv.register.domain.Category;
+import com.devcv.register.domain.Resume;
+import com.devcv.register.domain.ResumeImage;
+import com.devcv.register.domain.dto.CategoryDTO;
+import com.devcv.register.domain.dto.ResumeDTO;
+import com.devcv.register.domain.dto.ResumeImageDTO;
+import org.springframework.stereotype.Component;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import java.util.stream.Collectors;
+
+@Component
+public class ResumeMapper {
+
+    public static Resume dtoToEntity(ResumeDTO resumeDTO, Category category) {
+        List<ResumeImage> resumeImages = resumeDTO.getImageList() != null ? resumeDTO.getImageList().stream()
+                .map(ResumeImageMapper::dtoToEntity)
+                .collect(Collectors.toList()) : new ArrayList<>();
+
+        return Resume.builder()
+                .resumeId(resumeDTO.getResumeId())
+                .price(resumeDTO.getPrice())
+                .title(resumeDTO.getTitle())
+                .content(resumeDTO.getContent())
+                .resumeFilePath(resumeDTO.getResumeFilePath())
+                .status(resumeDTO.getResumeStatus())
+                .isStack(resumeDTO.getIsStack())
+                .imageList(resumeImages)
+                .category(category)
+                .build();
+    }
+
+
+    public static ResumeDTO entityToDto(Resume resume) {
+        List<ResumeImageDTO> resumeImageDTOS = resume.getImageList() != null ? resume.getImageList().stream()
+                .map(ResumeImageMapper::entityToDto)
+                .collect(Collectors.toList()) : new ArrayList<>();
+
+        CategoryDTO categoryDTO = CategoryDTO.builder()
+                .categoryId(resume.getCategory().getCategoryId())
+                .companyType(resume.getCategory().getCompanyType())
+                .stackType(resume.getCategory().getStackType())
+                .build();
+
+        return ResumeDTO.builder()
+                .resumeId(resume.getResumeId())
+                .price(resume.getPrice())
+                .title(resume.getTitle())
+                .content(resume.getContent())
+                .resumeFilePath(resume.getResumeFilePath())
+                .resumeStatus(resume.getStatus())
+                .isStack(resume.getIsStack())
+                .category(categoryDTO)
+                .imageList(resumeImageDTOS)
+                .build();
+    }
+
+}

--- a/src/main/java/com/devcv/register/application/ResumeService.java
+++ b/src/main/java/com/devcv/register/application/ResumeService.java
@@ -1,0 +1,15 @@
+package com.devcv.register.application;
+
+import com.devcv.register.domain.dto.ResumeDTO;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Transactional
+public interface ResumeService {
+    //이력서 판매등록
+    ResumeDTO register(ResumeDTO resumeDTO, MultipartFile resumeFile, List<MultipartFile> images);
+
+
+}

--- a/src/main/java/com/devcv/register/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/register/application/ResumeServiceImpl.java
@@ -1,0 +1,80 @@
+package com.devcv.register.application;
+
+import com.devcv.register.domain.Resume;
+import com.devcv.register.domain.Category;
+import com.devcv.common.util.S3Uploader;
+import com.devcv.register.domain.ResumeImage;
+import com.devcv.register.domain.dto.CategoryDTO;
+import com.devcv.register.domain.dto.ResumeDTO;
+import com.devcv.register.domain.dto.ResumeImageDTO;
+import com.devcv.register.domain.enumtype.ResumeStatus;
+import com.devcv.register.repository.CategoryRepository;
+import com.devcv.register.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.devcv.register.application.ResumeMapper.dtoToEntity;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ResumeServiceImpl implements ResumeService {
+
+   private  final ResumeRepository resumeRepository;
+   private final CategoryRepository categoryRepository;
+   private final S3Uploader s3Uploader;
+
+    @Override
+    public ResumeDTO register(ResumeDTO resumeDTO, MultipartFile resumeFile, List<MultipartFile> images) {
+        try {
+            // Category 저장
+            CategoryDTO categoryDTO = resumeDTO.getCategory();
+            Category category = categoryRepository.findByCompanyTypeAndStackType(
+                    categoryDTO.getCompanyType(),
+                    categoryDTO.getStackType()
+            ).orElseGet(() -> {
+                Category newCategory = new Category(categoryDTO.getCompanyType(), categoryDTO.getStackType());
+                return categoryRepository.save(newCategory);
+            });
+
+
+            // PDF 파일 업로드
+            String resumeFilePath = s3Uploader.upload(resumeFile);
+            log.debug(resumeFilePath);
+            resumeDTO.setResumeFilePath(resumeFilePath);
+
+            Resume resume = dtoToEntity(resumeDTO, category);
+
+            // 상세이미지 업로드
+            if (images != null && !images.isEmpty()) {
+                for (int i = 0; i < images.size(); i++) {
+                    MultipartFile image = images.get(i);
+                    String imagePath = s3Uploader.upload(image);
+                    ResumeImageDTO resumeImageDTO = ResumeImageDTO.builder()
+                            .resumeImgPath(imagePath)
+                            .ord(i)
+                            .build();
+                    resume.addImage(ResumeImageMapper.dtoToEntity(resumeImageDTO));
+                }
+            }
+
+            // 상태 설정
+            resume.setStatus(ResumeStatus.승인대기);
+
+            Resume savedResume = resumeRepository.save(resume);
+            log.info("Saved resume ID: " + savedResume.getResumeId());
+            return ResumeMapper.entityToDto(savedResume);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload file", e);
+        }
+    }
+
+}

--- a/src/main/java/com/devcv/register/domain/Category.java
+++ b/src/main/java/com/devcv/register/domain/Category.java
@@ -1,0 +1,35 @@
+package com.devcv.register.domain;
+
+import com.devcv.register.domain.enumtype.CompanyType;
+import com.devcv.register.domain.enumtype.StackType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "category")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    // 회사 카테고리
+    @Enumerated(EnumType.STRING)
+    private CompanyType companyType;
+
+    // 직무 카테고리
+    @Enumerated(EnumType.STRING)
+    private StackType stackType;
+
+    public Category(CompanyType companyType, StackType stackType) {
+        this.companyType = companyType;
+        this.stackType = stackType;
+    }
+}

--- a/src/main/java/com/devcv/register/domain/Resume.java
+++ b/src/main/java/com/devcv/register/domain/Resume.java
@@ -1,0 +1,68 @@
+package com.devcv.register.domain;
+
+import com.devcv.common.domain.BaseTimeEntity;
+import com.devcv.register.domain.enumtype.ResumeStatus;
+import com.devcv.register.infrastructure.ListStringConverter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tb_resume")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(exclude = "imageList")
+public class Resume extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long resumeId;
+
+    @Column(nullable = false)
+    private int price;
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private String resumeFilePath;
+
+    // 관리자 승인 상태 = 승인대기 default
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private ResumeStatus status = ResumeStatus.승인대기;
+
+    // 기술스택
+    @Convert(converter = ListStringConverter.class)
+    private List<String> isStack;
+
+    // 관련 이미지(썸네일, 상세이미지)
+    @ElementCollection
+    @Builder.Default
+    private List<ResumeImage> imageList = new ArrayList<>();// ResumeImage와 일대다 관계
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoryId", nullable = false)
+    private Category category;
+
+    public void addImage(ResumeImage image) {
+        image.setOrd(this.imageList.size());
+        imageList.add(image);
+    }
+
+    public void addImageString(String resumeImgPath) {
+        ResumeImage resumeImage = ResumeImage.builder()
+                .resumeImgPath(resumeImgPath)
+                .build();
+        addImage(resumeImage);
+    }
+
+
+
+
+}

--- a/src/main/java/com/devcv/register/domain/ResumeImage.java
+++ b/src/main/java/com/devcv/register/domain/ResumeImage.java
@@ -1,0 +1,23 @@
+package com.devcv.register.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@Getter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResumeImage {
+
+    // S3URL
+    private String resumeImgPath;
+    // 썸네일 이미지 번호 설정
+    private int ord;
+
+    public void setOrd(int ord) {
+        this.ord = ord;
+    }
+
+}

--- a/src/main/java/com/devcv/register/domain/dto/CategoryDTO.java
+++ b/src/main/java/com/devcv/register/domain/dto/CategoryDTO.java
@@ -1,0 +1,19 @@
+package com.devcv.register.domain.dto;
+
+import com.devcv.register.domain.enumtype.CompanyType;
+import com.devcv.register.domain.enumtype.StackType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryDTO {
+
+    private Long categoryId;
+    private CompanyType companyType;
+    private StackType stackType;
+}

--- a/src/main/java/com/devcv/register/domain/dto/ResumeDTO.java
+++ b/src/main/java/com/devcv/register/domain/dto/ResumeDTO.java
@@ -1,0 +1,33 @@
+package com.devcv.register.domain.dto;
+
+import com.devcv.register.domain.enumtype.ResumeStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResumeDTO {
+
+    private Long resumeId;
+    private int price;
+    private String title;
+    private String content;
+    private String resumeFilePath;
+    private List<String> isStack;
+    private ResumeStatus resumeStatus;
+    private CategoryDTO category;
+    @Builder.Default
+    private List<ResumeImageDTO> imageList = new ArrayList<>();
+
+
+
+}

--- a/src/main/java/com/devcv/register/domain/dto/ResumeImageDTO.java
+++ b/src/main/java/com/devcv/register/domain/dto/ResumeImageDTO.java
@@ -1,0 +1,15 @@
+package com.devcv.register.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResumeImageDTO {
+    private String resumeImgPath;
+    private int ord;
+}

--- a/src/main/java/com/devcv/register/domain/enumtype/CompanyType.java
+++ b/src/main/java/com/devcv/register/domain/enumtype/CompanyType.java
@@ -1,0 +1,5 @@
+package com.devcv.register.domain.enumtype;
+
+public enum CompanyType {
+    대기업, 중견기업, 중소기업, 스타트업, 유니콘기업, 공기업, 벤처기업
+}

--- a/src/main/java/com/devcv/register/domain/enumtype/ResumeStatus.java
+++ b/src/main/java/com/devcv/register/domain/enumtype/ResumeStatus.java
@@ -1,0 +1,9 @@
+package com.devcv.register.domain.enumtype;
+
+public enum ResumeStatus {
+    승인대기,
+    판매승인,
+    등록완료,
+    삭제,
+    반려
+}

--- a/src/main/java/com/devcv/register/domain/enumtype/StackType.java
+++ b/src/main/java/com/devcv/register/domain/enumtype/StackType.java
@@ -1,0 +1,4 @@
+package com.devcv.register.domain.enumtype;
+public enum StackType {
+    백엔드, 프론트엔드, 모바일, 인프라, 게임, 임베디드, 보안
+}

--- a/src/main/java/com/devcv/register/infrastructure/ListStringConverter.java
+++ b/src/main/java/com/devcv/register/infrastructure/ListStringConverter.java
@@ -1,0 +1,33 @@
+package com.devcv.register.infrastructure;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/*
+******************************** Converter ********************************
+* convertToDatabaseColumn : DB에 저장할 때 String값으로 바꿔주는 method
+* convertToEntityAttribute : DB에서 꺼내올 때 해당 Attribute로 바꿔주는 method
+******************************** Converter ********************************
+* */
+@Converter
+public class ListStringConverter implements AttributeConverter<List<String>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null; // 또는 적절한 기본값 반환
+        }
+        return String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(dbData.split(","));
+    }
+}

--- a/src/main/java/com/devcv/register/presentation/ResumeController.java
+++ b/src/main/java/com/devcv/register/presentation/ResumeController.java
@@ -1,0 +1,30 @@
+package com.devcv.register.presentation;
+
+import com.devcv.register.application.ResumeService;
+import com.devcv.register.domain.dto.ResumeDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/resumes")
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+
+    @PostMapping("/add")
+    public ResponseEntity<ResumeDTO> registerResume(
+            @RequestPart(value = "resume") ResumeDTO resumeDTO,
+            @RequestPart("resumeFile") MultipartFile resumeFile,
+            @RequestPart("images") List<MultipartFile> images) {
+        ResumeDTO createdResume = resumeService.register(resumeDTO, resumeFile, images);
+        return ResponseEntity.ok(createdResume);
+    }
+}

--- a/src/main/java/com/devcv/register/repository/CategoryRepository.java
+++ b/src/main/java/com/devcv/register/repository/CategoryRepository.java
@@ -1,0 +1,16 @@
+package com.devcv.register.repository;
+
+import com.devcv.register.domain.Category;
+import com.devcv.register.domain.enumtype.CompanyType;
+import com.devcv.register.domain.enumtype.StackType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT c FROM Category c WHERE c.companyType = :companyType AND c.stackType= :stackType")
+    Optional<Category> findByCompanyTypeAndStackType(CompanyType companyType, StackType stackType);
+
+}

--- a/src/main/java/com/devcv/register/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/register/repository/ResumeRepository.java
@@ -1,0 +1,9 @@
+package com.devcv.register.repository;
+
+import com.devcv.register.domain.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 

## 📝작업 내용

1. > Resume, Category Entity 설계
2. > aws s3 연동 및 ResumeFile, ResumeImage 업로드 기능 구현
3. > ResumeMapper, ResumeImageMapper 설정
4. > ResumeService 사이클 구현
5. > Controller 단 경로 호출 성공(추후 Return값 공통 response로 수정하겠습니다....😭)
6. > S3관련 ErrorCode 추가(태현님 이렇게 하는게 맞나요...?.........제가 뭔가 잘못 이해하고 쓰고 있는 것 같기도 하고....엉엉.....)

### 이슈

aws s3 업로드 후 UUID 변환 시 varchar(255) 이상일 시 sql insert가 실행되지 않는 이슈 발생
-> varchar domain 값 늘리기 고려...?


### 스크린샷 (선택)
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/1a99da25-c75e-482a-9070-c19765a6e312)


## 💬리뷰 요구사항(선택)

> 수정할 사항이 있다면 말씀해주세요!!! 떨립니다....매우...

