### PR TITLE
🐛 [Fix] resume 생성시 충돌 코드 수정 (#28)

### DIFF
--- a/src/main/java/com/devcv/member/domain/Member.java
+++ b/src/main/java/com/devcv/member/domain/Member.java
@@ -43,9 +43,8 @@ public class Member extends BaseTimeEntity {
     @Column(name = "address", nullable = false)
     private String address;
 
-    @Column
-    @OneToMany(mappedBy = "member")
-    private List<Point> points;
+    @Column(name = "point")
+    private Long point;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "social", nullable = false)
@@ -68,7 +67,7 @@ public class Member extends BaseTimeEntity {
     private List<String> stack;
 
     @Builder
-    public Member(Long userId, String userName, String email, String password, String nickName, String phone, String address, List<Point> points, SocialType social, RoleType userRole, CompanyType company, JobType job, List<String> stack) {
+    public Member(Long userId, String userName, String email, String password, String nickName, String phone, String address, Long point, SocialType social, RoleType userRole, CompanyType company, JobType job, List<String> stack) {
         this.userId = userId;
         this.userName = userName;
         this.email = email;
@@ -76,7 +75,7 @@ public class Member extends BaseTimeEntity {
         this.nickName = nickName;
         this.phone = phone;
         this.address = address;
-        this.points = points;
+        this.point = point;
         this.social = social;
         this.userRole = userRole;
         this.company = company;

--- a/src/main/java/com/devcv/member/domain/dto/MemberResponse.java
+++ b/src/main/java/com/devcv/member/domain/dto/MemberResponse.java
@@ -3,8 +3,10 @@ package com.devcv.member.domain.dto;
 import com.devcv.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class MemberResponse {
 
@@ -13,6 +15,6 @@ public class MemberResponse {
     private String userName;
     private String email;
     public static MemberResponse from(Member member) {
-        return new MemberResponse(member.getUserId(),member.getNickName(), member.getUserName(),member.getUserName());
+        return new MemberResponse(member.getUserId(),member.getNickName(), member.getUserName(), member.getEmail());
     }
 }


### PR DESCRIPTION
#️⃣연관된 이슈
> #28 

📝작업 내용
>MemberResponse의 기본 생성자를 추가하여 역직렬화 안되는 현상 수정.
>Member 엔티티의 Point 필드를 수정하여 Lazy Loading 문제를 임시 해결하였습니다. (추후 다시 수정 예정)

💬리뷰 요구사항
>