### PR TITLE
✨ [Feat] 이력서 목록, 카테고리별, 상세 조회 기능 구현 (#25)

### DIFF
--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -2,17 +2,26 @@ package com.devcv.resume.application;
 
 import com.devcv.member.domain.dto.MemberResponse;
 import com.devcv.resume.domain.Resume;
+import com.devcv.resume.domain.dto.PaginatedResumeResponse;
+import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeRequest;
+import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.StackType;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Transactional
 public interface ResumeService {
+    // 이력서 목록 조회
+    PaginatedResumeResponse findResumes(StackType stackType, CompanyType companyType, int page, int size);
+    // 이력서 상세 조회
+    ResumeDto getResumeDetail(Long resumeId);
     MemberResponse getMemberResponse(Long userId);
     //이력서 판매승인 요청
     Resume register(MemberResponse memberResponse, ResumeRequest resumeRequest);
-    // 이력서 판매등록 요청
+    // 이력서 등록완료 요청
     Resume completeRegistration(MemberResponse memberResponse, Long resumeId);
-    // 이력서 조회(상태구분을 위함)
+    // 이력서 조회(이력서 등록 기능 내 상태구분을 위함)
     Resume findRegisteredResumeByMember(Long memberId);
+
 }

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -1,29 +1,33 @@
 package com.devcv.resume.application;
 
 import com.devcv.common.exception.ErrorCode;
-import com.devcv.common.exception.InternalServerException;
 import com.devcv.member.domain.Member;
 import com.devcv.member.domain.dto.MemberResponse;
+import com.devcv.member.exception.NotNullException;
 import com.devcv.member.repository.MemberRepository;
 import com.devcv.resume.domain.Resume;
 import com.devcv.resume.domain.Category;
+import com.devcv.resume.domain.dto.*;
+import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.StackType;
 import com.devcv.resume.exception.MemberNotFoundException;
 import com.devcv.resume.exception.ResumeNotFoundException;
 import com.devcv.resume.infrastructure.S3Uploader;
 import com.devcv.resume.domain.ResumeImage;
-import com.devcv.resume.domain.dto.CategoryDto;
-import com.devcv.resume.domain.dto.ResumeRequest;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.repository.CategoryRepository;
 import com.devcv.resume.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-
+import java.util.stream.Collectors;
 
 
 @Service
@@ -37,6 +41,57 @@ public class ResumeServiceImpl implements ResumeService {
     private final MemberRepository memberRepository;
     private final S3Uploader s3Uploader;
 
+
+    @Override
+    public PaginatedResumeResponse findResumes(StackType stackType, CompanyType companyType, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Resume> resumePage;
+
+        if (stackType != null && companyType != null) {
+            // 직무 & 회사별 목록 조회
+            resumePage = resumeRepository.findApprovedResumesByStackTypeAndCompanyType(stackType, companyType, pageable);
+        } else if (stackType != null) {
+            // 직무별 목록 조회
+            resumePage = resumeRepository.findApprovedResumesByStackType(stackType, pageable);
+        } else if (companyType != null) {
+            // 회사별 목록 조회
+            resumePage = resumeRepository.findApprovedResumesByCompanyType(companyType, pageable);
+        } else {
+            // 전체 목록 조회
+            resumePage = resumeRepository.findApprovedResumes(pageable);
+        }
+
+        List<ResumeResponse> resumeDTOs = resumePage.getContent()
+                .stream()
+                .map(ResumeResponse::from)
+                .collect(Collectors.toList());
+
+        int currentPage = resumePage.getNumber() + 1;
+        int totalPages = resumePage.getTotalPages();
+        int startPage = Math.max(1, currentPage - 2);
+        int endPage = Math.min(totalPages, currentPage + 2);
+
+        return new PaginatedResumeResponse(
+                resumeDTOs,
+                resumePage.getTotalElements(),
+                resumePage.getNumberOfElements(),
+                currentPage,
+                totalPages,
+                resumePage.getSize(),
+                startPage,
+                endPage
+        );
+    }
+
+    @Override
+    public ResumeDto getResumeDetail(Long resumeId) {
+        Resume resume = resumeRepository.findByIdAndStatus(resumeId)
+                .orElseThrow(() -> new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND));
+
+        return ResumeDto.from(resume);
+    }
+
+
     @Override
     public MemberResponse getMemberResponse(Long userId) {
         Member member = memberRepository.findMemberByUserId(userId);
@@ -48,91 +103,86 @@ public class ResumeServiceImpl implements ResumeService {
 
     @Override
     public Resume register(MemberResponse memberResponse, ResumeRequest resumeRequest) {
-        try {
 
-            // 회원 아이디 조회, 추후 security 설정 시 삭제
-            Member member = memberRepository.findMemberByUserId(memberResponse.getUserId());
-            if (member == null) {
-                throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND);
-            }
-
-            // Category 저장
-            CategoryDto categoryDTO = resumeRequest.getCategory();
-            List<Category> categories = categoryRepository.findByCompanyTypeAndStackType(
-                    categoryDTO.getCompanyType(),
-                    categoryDTO.getStackType()
-            );
-            Category category;
-            if (categories.isEmpty()) {
-                // 리스트가 비어 있으면 새로운 Category 생성 및 저장
-                category = new Category(categoryDTO.getCompanyType(), categoryDTO.getStackType());
-                category = categoryRepository.save(category);
-            } else {
-                // 리스트가 비어 있지 않으면 첫 번째 요소 사용
-                category = categories.get(0);
-            }
-
-            // PDF 파일 업로드
-            String resumeFilePath = null;
-            if (resumeRequest.getResumeFile() != null) {
-                resumeFilePath = s3Uploader.upload(resumeRequest.getResumeFile());
-                log.debug("Uploaded resume file path: {}", resumeFilePath);
-            }
-
-            Resume resume = Resume.builder()
-                    .member(member)
-                    .price(resumeRequest.getPrice())
-                    .title(resumeRequest.getTitle())
-                    .content(resumeRequest.getContent())
-                    .resumeFilePath(resumeFilePath)
-                    .stack(resumeRequest.getStack())
-                    .category(category)
-                    .build();
-
-            // 이미지 파일 업로드
-            List<MultipartFile> imageFiles = resumeRequest.getImageFiles();
-            if (imageFiles != null && !imageFiles.isEmpty()) {
-                for (int i = 0; i < imageFiles.size(); i++) {
-                    String imagePath = s3Uploader.upload(imageFiles.get(i));
-                    ResumeImage resumeImage = ResumeImage.builder()
-                            .resumeImgPath(imagePath)
-                            .ord(i)
-                            .build();
-                    resume.addImage(resumeImage);
-                }
-            }
-
-            // 상태 설정
-            resume.setStatus(ResumeStatus.승인대기);
-
-            return resumeRepository.save(resume);
-
-
-        } catch (Exception e) {
-            e.fillInStackTrace();
-            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        // 회원 아이디 조회, 추후 security 설정 시 삭제
+        Member member = memberRepository.findMemberByUserId(memberResponse.getUserId());
+        if (member == null) {
+            throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND);
         }
+
+        // Category 저장
+        CategoryDto categoryDTO = resumeRequest.getCategory();
+        List<Category> categories = categoryRepository.findByCompanyTypeAndStackType(
+                categoryDTO.getCompanyType(),
+                categoryDTO.getStackType()
+        );
+        Category category;
+        if (categories.isEmpty()) {
+            // 리스트가 비어 있으면 새로운 Category 생성 및 저장
+            category = new Category(categoryDTO.getCompanyType(), categoryDTO.getStackType());
+            category = categoryRepository.save(category);
+        } else {
+            // 리스트가 비어 있지 않으면 첫 번째 요소 사용
+            category = categories.get(0);
+        }
+
+        // PDF 파일 업로드
+        String resumeFilePath = null;
+        if (resumeRequest.getResumeFile() != null) {
+            resumeFilePath = s3Uploader.upload(resumeRequest.getResumeFile());
+            log.debug("Uploaded resume file path: {}", resumeFilePath);
+        }
+
+        // 필수 데이터 검증
+        if (resumeRequest.getPrice() < 0 || resumeRequest.getTitle() == null
+                || resumeRequest.getContent() == null || resumeRequest.getCategory() == null) {
+            throw new NotNullException(ErrorCode.NULL_ERROR);
+        }
+
+        Resume resume = Resume.builder()
+                .member(member)
+                .price(resumeRequest.getPrice())
+                .title(resumeRequest.getTitle())
+                .content(resumeRequest.getContent())
+                .resumeFilePath(resumeFilePath)
+                .stack(resumeRequest.getStack())
+                .category(category)
+                .build();
+
+        // 이미지 파일 업로드
+        List<MultipartFile> imageFiles = resumeRequest.getImageFiles();
+        if (imageFiles != null && !imageFiles.isEmpty()) {
+            for (int i = 0; i < imageFiles.size(); i++) {
+                String imagePath = s3Uploader.upload(imageFiles.get(i));
+                ResumeImage resumeImage = ResumeImage.builder()
+                        .resumeImgPath(imagePath)
+                        .ord(i)
+                        .build();
+                resume.addImage(resumeImage);
+            }
+        }
+
+        // 일단 임의 판매승인, 추후 관리자 mvp 완성 시 변경
+        resume.setStatus(ResumeStatus.판매승인);
+
+//        // 상태 설정
+//        resume.setStatus(ResumeStatus.승인대기);
+
+        return resumeRepository.save(resume);
     }
 
     @Override
     public Resume completeRegistration(MemberResponse memberResponse, Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND));
 
-        try {
-            Resume resume = resumeRepository.findById(resumeId)
-                    .orElseThrow(() -> new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND));
-
-            Member member = memberRepository.findMemberByUserId(memberResponse.getUserId());
-            if (member == null) {
-                throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND);
-            }
-
-            resume.setStatus(ResumeStatus.등록완료);
-            return resumeRepository.save(resume);
-        }catch(Exception e) {
-            e.fillInStackTrace();
-            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        Member member = memberRepository.findMemberByUserId(memberResponse.getUserId());
+        if (member == null) {
+            throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
+        resume.setStatus(ResumeStatus.등록완료);
+        return resumeRepository.save(resume);
     }
 
     @Override
@@ -145,6 +195,5 @@ public class ResumeServiceImpl implements ResumeService {
             return pendingResume;
         }
     }
-
 
 }

--- a/src/main/java/com/devcv/resume/domain/dto/PaginatedResumeResponse.java
+++ b/src/main/java/com/devcv/resume/domain/dto/PaginatedResumeResponse.java
@@ -1,0 +1,27 @@
+package com.devcv.resume.domain.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaginatedResumeResponse {
+
+    private List<ResumeResponse> content;
+    private Long totalElements;
+    private int numberOfElements;
+    private int currentPage;
+    private int totalPages;
+    private int size;
+    private int startPage;
+    private int endPage;
+
+}
+

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
@@ -26,6 +26,7 @@ public class ResumeDto {
     private List<ResumeImage> imageList;
     private Long categoryId;
     private Long memberId;
+    private String sellerNickname;
 
     public static ResumeDto from(Resume resume) {
         return new ResumeDto(
@@ -38,7 +39,8 @@ public class ResumeDto {
                 resume.getStack(),
                 resume.getImageList(),
                 resume.getCategory().getCategoryId(),
-                resume.getMember().getUserId()
+                resume.getMember().getUserId(),
+                resume.getMember().getNickName()
         );
     }
 }

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeResponse.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeResponse.java
@@ -13,6 +13,7 @@ public class ResumeResponse {
     private int price;
     private String resumeFilePath;
     private String thumbnail;
+    private String sellerNickname;
 
 
     public static ResumeResponse from(Resume resume) {
@@ -21,7 +22,8 @@ public class ResumeResponse {
                 resume.getTitle(),
                 resume.getPrice(),
                 resume.getResumeFilePath(),
-                getThumbnailFromResume(resume) // 썸네일 이미지를 직접 가져오는 메서드
+                getThumbnailFromResume(resume), // 썸네일 이미지 직접 가져오기
+                resume.getMember().getNickName()
         );
     }
     private static String getThumbnailFromResume(Resume resume) {

--- a/src/main/java/com/devcv/resume/presentation/ResumeController.java
+++ b/src/main/java/com/devcv/resume/presentation/ResumeController.java
@@ -3,8 +3,11 @@ package com.devcv.resume.presentation;
 import com.devcv.member.domain.dto.MemberResponse;
 import com.devcv.resume.application.ResumeService;
 import com.devcv.resume.domain.Resume;
+import com.devcv.resume.domain.dto.PaginatedResumeResponse;
 import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeRequest;
+import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.StackType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +30,28 @@ import java.util.List;
 public class ResumeController {
 
     private final ResumeService resumeService;
+
+    //------------이력서 목록 조회 요청 start---------------
+    @GetMapping()
+    public ResponseEntity<PaginatedResumeResponse> getResumesByConditions(
+            @RequestParam("page") int page, @RequestParam("size") int size,
+            @RequestParam(value = "stackType", required = false) StackType stackType,
+            @RequestParam(value = "companyType", required = false) CompanyType companyType) {
+        PaginatedResumeResponse response = resumeService.findResumes(stackType, companyType, page, size);
+        return ResponseEntity.ok(response);
+    }
+    //------------이력서 목록 조회 요청 end---------------
+
+
+    //------------이력서 상세 조회 요청 start--------------
+    @GetMapping("/{resumeId}")
+    public ResponseEntity<ResumeDto> getResumeDetail(@PathVariable Long resumeId) {
+        ResumeDto resumeDetail = resumeService.getResumeDetail(resumeId);
+        return ResponseEntity.ok(resumeDetail);
+    }
+    //------------이력서 상세 조회 요청 end---------------
+
+
 
     //------이력서 등록 페이지 호출 start --------
     @GetMapping("/new")

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -1,9 +1,16 @@
 package com.devcv.resume.repository;
 
 import com.devcv.resume.domain.Resume;
+import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.ResumeStatus;
+import com.devcv.resume.domain.enumtype.StackType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
@@ -15,6 +22,41 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     // 승인대기 중인 이력서 조회
     @Query(value = "SELECT * FROM tb_resume r WHERE r.member_userid = :memberId AND r.status = '승인대기' ORDER BY r.created_date ASC LIMIT 1", nativeQuery = true)
     Resume findFirstPendingByMemberIdOrderByCreatedAtAsc(@Param("memberId") Long memberId);
+
+    // 상세 이력서 조회
+    @Query("SELECT r FROM Resume r WHERE r.resumeId = :resumeId AND r.status = '등록완료'")
+    Optional<Resume> findByIdAndStatus(Long resumeId);
+
+    // 기본 이력서 조회
+    Page<Resume> findByStatus(ResumeStatus status, Pageable pageable);
+
+    // 직무 & 회사별 이력서 조회
+    Page<Resume> findByCategory_StackTypeAndCategory_CompanyTypeAndStatus(StackType stackType, CompanyType companyType, ResumeStatus status, Pageable pageable);
+
+    // 직무별 이력서 조회
+    Page<Resume> findByCategory_StackTypeAndStatus(StackType stackType, ResumeStatus status, Pageable pageable);
+
+    // 회사별 이력서 조회
+    Page<Resume> findByCategory_CompanyTypeAndStatus(CompanyType companyType, ResumeStatus status, Pageable pageable);
+
+    //----------------등록완료 default인 메서드 start-----------------
+    default Page<Resume> findApprovedResumes(Pageable pageable) {
+        return findByStatus(ResumeStatus.등록완료, pageable);
+    }
+    default Page<Resume> findApprovedResumesByStackTypeAndCompanyType(StackType stackType, CompanyType companyType, Pageable pageable) {
+        return findByCategory_StackTypeAndCategory_CompanyTypeAndStatus(stackType, companyType, ResumeStatus.등록완료, pageable);
+    }
+
+    default Page<Resume> findApprovedResumesByStackType(StackType stackType, Pageable pageable) {
+        return findByCategory_StackTypeAndStatus(stackType, ResumeStatus.등록완료, pageable);
+    }
+
+    default Page<Resume> findApprovedResumesByCompanyType(CompanyType companyType, Pageable pageable) {
+        return findByCategory_CompanyTypeAndStatus(companyType, ResumeStatus.등록완료, pageable);
+    }
+
+    //----------------판매승인이 default인 메서드 end-----------------
+
 
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 이력서 전체목록, 카테고리별, 상세 조회 기능 추가
> 이력서 등록 일부 에러처리 수정(try-catch 블록 제거 및 개별 error throw로 변경 , NULL_ERROR 추가)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 페이지네이션 내려줄 데이터는 postman에서 확인 가능합니다...!
> 이력서 등록 부분 보다 자세한 순서도가 필요할 것 같아[ NOTION](https://www.notion.so/API-d296da1b2f5f4db7af17801c04727fc8?pvs=4) 에 추가했습니다. 혹시 제가 놓치는 부분이 있다면 알려주세요..!🙌
>
