### PR TITLE
✨ [Feat] 출석체크 이벤트 기능 MVP 구현 (#37)

### DIFF
--- a/src/main/java/com/devcv/event/application/AttendanceEventService.java
+++ b/src/main/java/com/devcv/event/application/AttendanceEventService.java
@@ -1,0 +1,55 @@
+package com.devcv.event.application;
+
+import com.devcv.common.exception.ErrorCode;
+import com.devcv.common.exception.TestErrorException;
+import com.devcv.event.domain.AttendanceEvent;
+import com.devcv.event.domain.Event;
+import com.devcv.event.domain.dto.AttendanceRequest;
+import com.devcv.event.repository.AttendanceEventRepository;
+import com.devcv.member.application.MemberService;
+import com.devcv.member.domain.Member;
+import com.devcv.point.application.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceEventService {
+
+    private final static Long ATTENDANCE_POINT = 1000L;
+
+    private final AttendanceEventRepository attendanceEventRepository;
+    private final PointService pointService;
+    private final MemberService memberService;
+    private final EventService eventService;
+
+    @Transactional
+    public AttendanceEvent checkAttendance(AttendanceRequest request) {
+
+        Event event = eventService.findByEventId(request.eventId());
+        Member member = memberService.findMemberByUserId(request.memberId());
+
+        checkExist(member, event);
+        savePoint(member, event);
+        return record(member, event);
+    }
+
+    private void checkExist(Member member, Event event) {
+        LocalDate today = LocalDate.now();
+        if (attendanceEventRepository.existsByMemberAndEventAndDate(member, event, today)) {
+            throw new TestErrorException(ErrorCode.TEST_ERROR);
+        }
+    }
+
+    private AttendanceEvent record(Member member, Event event) {
+        AttendanceEvent attendanceEvent = AttendanceEvent.of(member, event);
+        return attendanceEventRepository.save(attendanceEvent);
+    }
+
+    private void savePoint(Member member, Event event) {
+        pointService.savePoint(member, ATTENDANCE_POINT, event.getName());
+    }
+}

--- a/src/main/java/com/devcv/event/application/AttendanceEventService.java
+++ b/src/main/java/com/devcv/event/application/AttendanceEventService.java
@@ -4,6 +4,7 @@ import com.devcv.common.exception.ErrorCode;
 import com.devcv.common.exception.TestErrorException;
 import com.devcv.event.domain.AttendanceEvent;
 import com.devcv.event.domain.Event;
+import com.devcv.event.domain.dto.AttendanceListResponse;
 import com.devcv.event.domain.dto.AttendanceRequest;
 import com.devcv.event.repository.AttendanceEventRepository;
 import com.devcv.member.application.MemberService;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -51,5 +54,19 @@ public class AttendanceEventService {
 
     private void savePoint(Member member, Event event) {
         pointService.savePoint(member, ATTENDANCE_POINT, event.getName());
+    }
+
+    @Transactional
+    public AttendanceListResponse getAttendanceListResponse(AttendanceRequest request) {
+        Member member = memberService.findMemberByUserId(request.memberId());
+        Event event = eventService.findByEventId(request.eventId());
+
+        LocalDate startDate = LocalDate.from(event.getStartDate());
+        LocalDate endDate = LocalDate.from(event.getEndDate());
+
+        List<LocalDateTime> attendanceDateList = attendanceEventRepository
+                .findCreatedDateByMemberAndDateRange(member, event, startDate, endDate);
+
+        return AttendanceListResponse.of(member.getUserId(), attendanceDateList);
     }
 }

--- a/src/main/java/com/devcv/event/application/EventService.java
+++ b/src/main/java/com/devcv/event/application/EventService.java
@@ -1,5 +1,7 @@
 package com.devcv.event.application;
 
+import com.devcv.common.exception.ErrorCode;
+import com.devcv.common.exception.TestErrorException;
 import com.devcv.event.domain.Event;
 import com.devcv.event.domain.dto.EventRequest;
 import com.devcv.event.repository.EventRepository;
@@ -15,5 +17,10 @@ public class EventService {
     public Event createEvent(EventRequest eventRequest) {
         Event event = Event.of(eventRequest.name(), eventRequest.startDate(), eventRequest.endDate());
         return eventRepository.save(event);
+    }
+
+    public Event findByEventId(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new TestErrorException(ErrorCode.TEST_ERROR));
     }
 }

--- a/src/main/java/com/devcv/event/application/EventService.java
+++ b/src/main/java/com/devcv/event/application/EventService.java
@@ -1,0 +1,19 @@
+package com.devcv.event.application;
+
+import com.devcv.event.domain.Event;
+import com.devcv.event.domain.dto.EventRequest;
+import com.devcv.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public Event createEvent(EventRequest eventRequest) {
+        Event event = Event.of(eventRequest.name(), eventRequest.startDate(), eventRequest.endDate());
+        return eventRepository.save(event);
+    }
+}

--- a/src/main/java/com/devcv/event/domain/AttendanceEvent.java
+++ b/src/main/java/com/devcv/event/domain/AttendanceEvent.java
@@ -1,0 +1,37 @@
+package com.devcv.event.domain;
+
+import com.devcv.common.domain.BaseTimeEntity;
+import com.devcv.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tb_attendance_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceEvent extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    private AttendanceEvent(Member member, Event event) {
+        this.id = null;
+        this.member = member;
+        this.event = event;
+    }
+
+    public static AttendanceEvent of(Member member, Event event) {
+        return new AttendanceEvent(member, event);
+    }
+}

--- a/src/main/java/com/devcv/event/domain/Event.java
+++ b/src/main/java/com/devcv/event/domain/Event.java
@@ -1,0 +1,40 @@
+package com.devcv.event.domain;
+
+import com.devcv.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "tb_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private LocalDateTime startDate;
+
+    @Column
+    private LocalDateTime endDate;
+
+    private Event(String name, LocalDateTime startDate, LocalDateTime endDate) {
+        this.id = null;
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public static Event of(String name, LocalDateTime startDate, LocalDateTime endDate) {
+        return new Event(name, startDate, endDate);
+    }
+}

--- a/src/main/java/com/devcv/event/domain/dto/AttendanceListResponse.java
+++ b/src/main/java/com/devcv/event/domain/dto/AttendanceListResponse.java
@@ -1,0 +1,12 @@
+package com.devcv.event.domain.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AttendanceListResponse(Long memberId, List<LocalDateTime> attendanceDateList) {
+
+    public static AttendanceListResponse of(Long memberId, List<LocalDateTime> attendanceDateList) {
+        return new AttendanceListResponse(memberId, attendanceDateList);
+    }
+}

--- a/src/main/java/com/devcv/event/domain/dto/AttendanceRequest.java
+++ b/src/main/java/com/devcv/event/domain/dto/AttendanceRequest.java
@@ -1,0 +1,5 @@
+package com.devcv.event.domain.dto;
+
+public record AttendanceRequest(Long eventId, Long memberId) {
+
+}

--- a/src/main/java/com/devcv/event/domain/dto/EventRequest.java
+++ b/src/main/java/com/devcv/event/domain/dto/EventRequest.java
@@ -1,0 +1,7 @@
+package com.devcv.event.domain.dto;
+
+import java.time.LocalDateTime;
+
+public record EventRequest(String name, LocalDateTime startDate, LocalDateTime endDate) {
+
+}

--- a/src/main/java/com/devcv/event/presentation/AttendanceController.java
+++ b/src/main/java/com/devcv/event/presentation/AttendanceController.java
@@ -2,6 +2,7 @@ package com.devcv.event.presentation;
 
 import com.devcv.event.application.AttendanceEventService;
 import com.devcv.event.domain.AttendanceEvent;
+import com.devcv.event.domain.dto.AttendanceListResponse;
 import com.devcv.event.domain.dto.AttendanceRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,15 @@ public class AttendanceController {
 
     private final AttendanceEventService attendanceEventService;
 
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<Object> checkAttendance(@RequestBody AttendanceRequest request) {
         AttendanceEvent attendanceEvent = attendanceEventService.checkAttendance(request);
         return ResponseEntity.created(URI.create(String.valueOf(attendanceEvent.getId()))).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getAttendanceList(@RequestBody AttendanceRequest request) { //임시 dto
+        AttendanceListResponse response = attendanceEventService.getAttendanceListResponse(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/devcv/event/presentation/AttendanceController.java
+++ b/src/main/java/com/devcv/event/presentation/AttendanceController.java
@@ -1,0 +1,24 @@
+package com.devcv.event.presentation;
+
+import com.devcv.event.application.AttendanceEventService;
+import com.devcv.event.domain.AttendanceEvent;
+import com.devcv.event.domain.dto.AttendanceRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/events/attendance")
+public class AttendanceController {
+
+    private final AttendanceEventService attendanceEventService;
+
+    @PostMapping("/")
+    public ResponseEntity<Object> checkAttendance(@RequestBody AttendanceRequest request) {
+        AttendanceEvent attendanceEvent = attendanceEventService.checkAttendance(request);
+        return ResponseEntity.created(URI.create(String.valueOf(attendanceEvent.getId()))).build();
+    }
+}

--- a/src/main/java/com/devcv/event/presentation/EventController.java
+++ b/src/main/java/com/devcv/event/presentation/EventController.java
@@ -1,0 +1,24 @@
+package com.devcv.event.presentation;
+
+import com.devcv.event.application.EventService;
+import com.devcv.event.domain.Event;
+import com.devcv.event.domain.dto.EventRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping("/")
+    public ResponseEntity<Object> createEvent(@RequestBody EventRequest eventRequest) {
+        Event event = eventService.createEvent(eventRequest);
+        return ResponseEntity.created(URI.create(String.valueOf(event.getId()))).build();
+    }
+}

--- a/src/main/java/com/devcv/event/presentation/EventController.java
+++ b/src/main/java/com/devcv/event/presentation/EventController.java
@@ -16,7 +16,7 @@ public class EventController {
 
     private final EventService eventService;
 
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<Object> createEvent(@RequestBody EventRequest eventRequest) {
         Event event = eventService.createEvent(eventRequest);
         return ResponseEntity.created(URI.create(String.valueOf(event.getId()))).build();

--- a/src/main/java/com/devcv/event/repository/AttendanceEventRepository.java
+++ b/src/main/java/com/devcv/event/repository/AttendanceEventRepository.java
@@ -1,0 +1,24 @@
+package com.devcv.event.repository;
+
+import com.devcv.event.domain.AttendanceEvent;
+import com.devcv.event.domain.Event;
+import com.devcv.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+
+public interface AttendanceEventRepository extends JpaRepository<AttendanceEvent, Long> {
+
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM AttendanceEvent a " +
+            "WHERE a.member = :member " +
+            "AND a.event = :event " +
+            "AND DATE(a.createdDate) = :createdDate")
+    boolean existsByMemberAndEventAndDate(
+            @Param("member") Member member,
+            @Param("event") Event event,
+            @Param("createdDate") LocalDate createdDate
+    );
+}

--- a/src/main/java/com/devcv/event/repository/AttendanceEventRepository.java
+++ b/src/main/java/com/devcv/event/repository/AttendanceEventRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface AttendanceEventRepository extends JpaRepository<AttendanceEvent, Long> {
 
@@ -21,4 +23,16 @@ public interface AttendanceEventRepository extends JpaRepository<AttendanceEvent
             @Param("event") Event event,
             @Param("createdDate") LocalDate createdDate
     );
+
+    @Query("SELECT a.createdDate " +
+            "FROM AttendanceEvent a " +
+            "WHERE a.member = :member " +
+            "AND a.event = :event " +
+            "AND DATE(a.createdDate) BETWEEN :startDate AND :endDate")
+    List<LocalDateTime> findCreatedDateByMemberAndDateRange(@Param("member") Member member,
+                                                            @Param("event") Event event,
+                                                            @Param("startDate") LocalDate startDate,
+                                                            @Param("endDate") LocalDate endDate);
+
+//    List<AttendanceEvent> findAttendanceEventsByMemberAndEvent(Member member, Event event);
 }

--- a/src/main/java/com/devcv/event/repository/EventRepository.java
+++ b/src/main/java/com/devcv/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.devcv.event.repository;
+
+import com.devcv.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37 
## 📝작업 내용

>
> 1 관리자가 이벤트를 생성 ex) 6월 출석 이벤트(6.1~6.30)
> 2 이 이벤트id를 참조하여 출석체크 로그 생성 + 포인트 지급
> 3 유저별 참여 내역 조회
>
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

오늘중으로 postman에 정리해두겠습니다
