### PR TITLE
✨ [Feat] 이력서 등록 기능 security 추가 (#40)

### DIFF
--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -4,6 +4,7 @@ import com.devcv.auth.filter.JwtAccessDeniedHandler;
 import com.devcv.auth.filter.JwtAuthenticationEntryPoint;
 import com.devcv.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,6 +19,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@Slf4j
 public class SpringSecurityConfig {
     private final JwtProvider jwtProvider;
     private final CorsFilter corsFilter;
@@ -32,6 +34,7 @@ public class SpringSecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        log.debug("Configuring SecurityFilterChain");
         // CSRF 설정 Disable
         http.csrf().disable()
                 // CORS 설정
@@ -57,7 +60,7 @@ public class SpringSecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers("/members/login","/members/signup","/members/findid","/members/certemail"
                         ,"/members/findpwphone","/members/findpwemail","/members/modipw","/members/duplicationemail",
-                        "/auth/kakao","/auth/google").permitAll()
+                        "/auth/kakao","/auth/google", "/api/resumes","/api/resumes/{resumeId}").permitAll()
                 .anyRequest().authenticated()   // 이외 인증필요 -> Header에 "Bearer {accessToken}" 형태로 요청
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용

--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     EMPTY_FILE_EXCEPTION("입력받은 이미지 파일이 빈 파일입니다."),
     NO_FILE_EXTENTION("파일 확장자가 없습니다."),
     INVALID_FILE_EXTENTION("유효하지 않은 파일 확장자입니다."),
+    EMPTY_VALUE_ERROR("필수 입력 값이 비어있습니다."),
 
     //401
     UNAUTHORIZED_ERROR("인증에 실패하였습니다."),

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -12,8 +12,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.PropertyValueException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
 
 @Slf4j
 @RestControllerAdvice
@@ -92,6 +94,14 @@ public class GlobalExceptionHandler {
     }
     // 404 end
 
+    // 400 start
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handle(HttpMessageNotReadableException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ErrorCode.EMPTY_VALUE_ERROR));
+    }
+    // 400 end
 
     @ExceptionHandler(S3Exception.class)
     public ResponseEntity<ErrorResponse>handle(S3Exception e) {

--- a/src/main/java/com/devcv/event/application/AttendanceEventService.java
+++ b/src/main/java/com/devcv/event/application/AttendanceEventService.java
@@ -33,7 +33,7 @@ public class AttendanceEventService {
     public AttendanceEvent checkAttendance(AttendanceRequest request) {
 
         Event event = eventService.findByEventId(request.eventId());
-        Member member = memberService.findMemberByUserId(request.memberId());
+        Member member = memberService.findMemberByMemberId(request.memberId());
 
         checkExist(member, event);
         savePoint(member, event);
@@ -58,7 +58,7 @@ public class AttendanceEventService {
 
     @Transactional
     public AttendanceListResponse getAttendanceListResponse(AttendanceRequest request) {
-        Member member = memberService.findMemberByUserId(request.memberId());
+        Member member = memberService.findMemberByMemberId(request.memberId());
         Event event = eventService.findByEventId(request.eventId());
 
         LocalDate startDate = LocalDate.from(event.getStartDate());
@@ -67,6 +67,6 @@ public class AttendanceEventService {
         List<LocalDateTime> attendanceDateList = attendanceEventRepository
                 .findCreatedDateByMemberAndDateRange(member, event, startDate, endDate);
 
-        return AttendanceListResponse.of(member.getUserId(), attendanceDateList);
+        return AttendanceListResponse.of(member.getMemberId(), attendanceDateList);
     }
 }

--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -20,7 +20,7 @@ public interface ResumeService {
     //이력서 판매승인 요청
     Resume register(MemberResponse memberResponse, ResumeRequest resumeRequest);
     // 이력서 판매내역 상세 조회
-    ResumeDto getRegisterResumeDetail(Long resumeId);
+    ResumeDto getRegisterResumeDetail(Long memberId, Long resumeId);
     // 이력서 등록완료 요청
-    Resume completeRegistration(MemberResponse memberResponse, Long resumeId);
+    Resume completeRegistration(Long memberId, Long resumeId);
 }

--- a/src/main/java/com/devcv/resume/domain/Category.java
+++ b/src/main/java/com/devcv/resume/domain/Category.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "category")
+@Table(name = "tb_category")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeRequest.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeRequest.java
@@ -10,8 +10,7 @@ import java.util.List;
 @Getter
 @Setter
 public class ResumeRequest {
-    private Long memberid;  // 추후 @AuthenticationPrincipal을 사용할 때는 필요 없음, 삭제 예정
-    private int price;
+    private Integer price;
     private String title;
     private String content;
     private MultipartFile resumeFile;

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeResponse.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeResponse.java
@@ -1,6 +1,8 @@
 package com.devcv.resume.domain.dto;
 
 import com.devcv.resume.domain.Resume;
+import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.StackType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,6 +16,8 @@ public class ResumeResponse {
     private String resumeFilePath;
     private String thumbnail;
     private String sellerNickname;
+    private StackType stackType;
+    private CompanyType companyType;
 
 
     public static ResumeResponse from(Resume resume) {
@@ -23,7 +27,9 @@ public class ResumeResponse {
                 resume.getPrice(),
                 resume.getResumeFilePath(),
                 getThumbnailFromResume(resume), // 썸네일 이미지 직접 가져오기
-                resume.getMember().getNickName()
+                resume.getMember().getNickName(),
+                resume.getCategory().getStackType(),
+                resume.getCategory().getCompanyType()
         );
     }
     private static String getThumbnailFromResume(Resume resume) {

--- a/src/main/java/com/devcv/resume/exception/HttpMessageNotReadableException.java
+++ b/src/main/java/com/devcv/resume/exception/HttpMessageNotReadableException.java
@@ -1,0 +1,12 @@
+package com.devcv.resume.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class HttpMessageNotReadableException extends CustomException {
+
+    public HttpMessageNotReadableException(ErrorCode errorCode) {super(errorCode);}
+
+    public HttpMessageNotReadableException(ErrorCode errorCode, String message) {super(errorCode, message);}
+
+}

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -16,8 +15,8 @@ import java.util.Optional;
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
     // 판매내역 이력서 상세 조회
-    @Query("SELECT r FROM Resume r WHERE r.resumeId = :resumeId")
-    Optional<Resume> findById(Long resumeId);
+    @Query("SELECT r FROM Resume r WHERE r.resumeId = :resumeId AND r.member.memberId = :memberId")
+    Optional<Resume> findByIdAndMemberId(Long resumeId, Long memberId);
 
     // 기본 이력서 조회
     Page<Resume> findByStatus(ResumeStatus status, Pageable pageable);


### PR DESCRIPTION
# #️⃣연관된 이슈

> #40 
## 📝작업 내용

> 1. Resume 도메인 내 이력서 등록 / 이력서 판매 등록 / 이력서 판매 내역 상세 조회 Bearer {token} 헤더 추가, 파라미터 수정
> 2. table(name=category) -> table(name=tb_category) 변경
      -> resume_image_list는 table이 아닌 값타입 객체라 tb 명시에서 제외했습니다..!
> 3. 인증 권한 예외처리 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> @pangyosim  화요일 미팅날 간단히 auth 도메인 흐름 설명 부탁드려도 될까요....?😭 제가 부족하여...auth 부분 이해하느라 애로사항이 많습니다..크흡....ㅠㅠ

