### PR TITLE
✨ [Feat] 이력서 등록 및 수정 기능 추가

### DIFF
--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     RESUME_NOT_FOUND("이력서를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND("회원 정보를 찾을 수 없습니다."),
     ORDER_NOT_FOUND("주문 정보를 찾을 수 없습니다"),
+    RESUME_NOT_EXIST("삭제된 이력서입니다"),
     //409
     CONFLICT_ERROR("요청 충돌 에러"),
     REVIEW_ALREADY_EXISTS("이미 이력서에 대한 구매후기를 작성했습니다."),

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.devcv.auth.exception.JwtUnsupportedException;
 import com.devcv.common.exception.dto.ErrorResponse;
 import com.devcv.member.exception.*;
 import com.devcv.resume.exception.MemberNotFoundException;
+import com.devcv.resume.exception.ResumeNotExistException;
 import com.devcv.resume.exception.ResumeNotFoundException;
 import com.devcv.resume.exception.S3Exception;
 import com.devcv.member.exception.AuthLoginException;
@@ -146,6 +147,13 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.from(ErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(ResumeNotExistException.class)
+    public ResponseEntity<ErrorResponse> handle(ResumeNotExistException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.from(ErrorCode.RESUME_NOT_EXIST));
     }
     // 404 end
 

--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -26,5 +26,8 @@ public interface ResumeService {
     Resume completeRegistration(Long memberId, Long resumeId);
     // 이력서 엔티티 가져오기
     Resume findByResumeId(Long resumeId);
-
+    // 이력서 등록 수정
+    ResumeDto modify(Long resumeId, Long memberId, ResumeDto resumeDto, MultipartFile resumeFile, List<MultipartFile> images);
+    // 이력서 삭제
+    Resume remove(Long resumeId, Long memberId);
 }

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -101,6 +101,10 @@ public class ResumeServiceImpl implements ResumeService {
     public ResumeDto getResumeDetail(Long resumeId) {
         List<Object[]>result = resumeRepository.findByIdAndStatus(resumeId);
 
+        if (result.isEmpty() || result.get(0) == null || result.get(0)[0] == null) {
+            throw new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND);
+        }
+
         Resume resume = (Resume) result.get(0)[0];
 
         Double averageGrade = (Double) result.get(0)[1];

--- a/src/main/java/com/devcv/resume/domain/Resume.java
+++ b/src/main/java/com/devcv/resume/domain/Resume.java
@@ -33,6 +33,8 @@ public class Resume extends BaseTimeEntity{
     private String content;
     @Column(nullable = false)
     private String resumeFilePath;
+    @Column(nullable = false)
+    private boolean delFlag;
 
     // 관리자 승인 상태 = 승인대기 default
     @Builder.Default
@@ -61,6 +63,36 @@ public class Resume extends BaseTimeEntity{
         image.setOrd(this.imageList.size());
         imageList.add(image);
     }
+
+    // 수정 관련 메서드
+    public void changePrice(Integer price) {
+        this.price = price;
+    }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    public void changeResumeFilePath(String resumeFilePath) {
+        this.resumeFilePath = resumeFilePath;
+    }
+
+
+    public void changeStack(List<String> stack) {
+        this.stack = stack;
+    }
+    public void changeCategory(Category category) {
+        this.category = category;
+    }
+
+    public void clearList() {
+        this.imageList.clear();
+    }
+
 
     public void addImageString(String resumeImgPath) {
         ResumeImage resumeImage = ResumeImage.builder()

--- a/src/main/java/com/devcv/resume/domain/dto/CategoryDto.java
+++ b/src/main/java/com/devcv/resume/domain/dto/CategoryDto.java
@@ -1,5 +1,6 @@
 package com.devcv.resume.domain.dto;
 
+import com.devcv.resume.domain.Category;
 import com.devcv.resume.domain.enumtype.CompanyType;
 import com.devcv.resume.domain.enumtype.StackType;
 import lombok.AllArgsConstructor;
@@ -16,4 +17,12 @@ public class CategoryDto {
     private Long categoryId;
     private CompanyType companyType;
     private StackType stackType;
+
+    public static CategoryDto from(Category category) {
+        return CategoryDto.builder()
+                .categoryId(category.getCategoryId())
+                .companyType(category.getCompanyType())
+                .stackType(category.getStackType())
+                .build();
+    }
 }

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
@@ -3,9 +3,7 @@ package com.devcv.resume.domain.dto;
 
 import com.devcv.resume.domain.Resume;
 import com.devcv.resume.domain.ResumeImage;
-import com.devcv.resume.domain.enumtype.CompanyType;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
-import com.devcv.resume.domain.enumtype.StackType;
 import lombok.*;
 
 import java.util.List;
@@ -25,8 +23,7 @@ public class ResumeDto {
     private ResumeStatus status;
     private List<String> stack;
     private List<ResumeImage> imageList;
-    private StackType stackType;
-    private CompanyType companyType;
+    private CategoryDto category;
     private Long memberId;
     private String sellerNickname;
 
@@ -44,8 +41,7 @@ public class ResumeDto {
                 resume.getStatus(),
                 resume.getStack(),
                 resume.getImageList(),
-                resume.getCategory().getStackType(),
-                resume.getCategory().getCompanyType(),
+                CategoryDto.from(resume.getCategory()),
                 resume.getMember().getMemberId(),
                 resume.getMember().getNickName(),
                 null,
@@ -65,8 +61,7 @@ public class ResumeDto {
                 .memberId(resume.getMember().getMemberId())
                 .sellerNickname(resume.getMember().getNickName())
                 .imageList(resume.getImageList())
-                .companyType(resume.getCategory().getCompanyType())
-                .stackType(resume.getCategory().getStackType())
+                .category(CategoryDto.from(resume.getCategory()))
                 .build();
 
         resumeDto.setAverageGrade(averageGrade);
@@ -75,4 +70,5 @@ public class ResumeDto {
         return resumeDto;
 
     }
+
 }

--- a/src/main/java/com/devcv/resume/exception/ResumeNotExistException.java
+++ b/src/main/java/com/devcv/resume/exception/ResumeNotExistException.java
@@ -1,0 +1,10 @@
+package com.devcv.resume.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class ResumeNotExistException extends CustomException {
+    public ResumeNotExistException(ErrorCode errorCode) {super(errorCode);}
+
+    public ResumeNotExistException(ErrorCode errorCode, String message) {super(errorCode, message);}
+}

--- a/src/main/java/com/devcv/resume/presentation/ResumeController.java
+++ b/src/main/java/com/devcv/resume/presentation/ResumeController.java
@@ -3,13 +3,16 @@ package com.devcv.resume.presentation;
 import com.devcv.common.exception.ErrorCode;
 import com.devcv.common.exception.InternalServerException;
 import com.devcv.common.exception.UnAuthorizedException;
+import com.devcv.member.application.MemberService;
 import com.devcv.resume.application.ResumeService;
 import com.devcv.resume.domain.Resume;
 import com.devcv.resume.domain.dto.PaginatedResumeResponse;
 import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeRequest;
 import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.domain.enumtype.StackType;
+import com.devcv.resume.exception.ResumeNotExistException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -90,6 +94,11 @@ public class ResumeController {
         Long memberId = Long.valueOf(userDetails.getUsername());
         ResumeDto resumeDetail = resumeService.getRegisterResumeDetail(memberId, resumeId);
 
+        // 삭제한 이력서 호출 시 접근 예외처리
+        if (resumeDetail.getStatus() == ResumeStatus.삭제) {
+            throw new ResumeNotExistException(ErrorCode.RESUME_NOT_EXIST);
+        }
+
         return ResponseEntity.ok().body(resumeDetail);
     }
     //----------이력서 판매 상세 내역 페이지 페이지 호출 end-----------
@@ -109,6 +118,45 @@ public class ResumeController {
         return ResponseEntity.ok(ResumeDto.from(completedResume));
     }
     //----------이력서 판매 등록 요청 end----------------
+
+
+    // ----------이력서 수정 등록 요청 start----------------
+    @PutMapping("/{resume-id}")
+    public ResponseEntity<ResumeDto> modifyResume(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable ("resume-id") Long resumeId,
+            @RequestPart("resume") ResumeDto resumeDto,
+            @RequestPart("resumeFile") MultipartFile resumeFile,
+            @RequestPart("images") List<MultipartFile> images) {
+
+        if(userDetails == null) {
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED_ERROR);
+        }
+        Long memberId = Long.valueOf(userDetails.getUsername());
+
+        ResumeDto updatedResume = resumeService.modify(resumeId, memberId, resumeDto, resumeFile, images);
+        return ResponseEntity.ok(updatedResume);
+    }
+    // ----------이력서 수정 등록 요청 end----------------
+
+
+
+    // ----------이력서 삭제 등록 요청 start----------------
+    @DeleteMapping("/{resume-id}")
+    public  Map<String, Object> removeResume(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("resume-id") Long resumeId) {
+
+        if (userDetails == null) {
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED_ERROR);
+        }
+        Long memberId = Long.valueOf(userDetails.getUsername());
+
+        Resume completedResume = resumeService.remove(resumeId, memberId);
+
+        return Map.of("resumeStatus" , completedResume.getStatus());
+    }
+    // ----------이력서 삭제 등록 요청 end----------------
 
 
 

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -76,6 +77,11 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     }
 
     //----------------판매승인이 default인 메서드 end-----------------
+
+    // 이력서 삭제
+    @Modifying
+    @Query("UPDATE Resume r set r.delFlag = :flag where r.resumeId = :resumeId")
+    void updateToDelete(Long resumeId, boolean flag);
 
 
 }


### PR DESCRIPTION
# #️⃣연관된 이슈
> #54 

## 📝작업 내용

> 1. Resume 엔티티 수정 관련 메서드 추가
> 2. Category {id, stacktype, companytype} 조회를 위한 DTO 수정
> 3. 이력서 수정 및 삭제 기능 구현



### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

-> 이력서 삭제의 경우 일단 resumeStatus : "삭제" 상태변경하는 것으로 진행했습니다.
추후 이력서 파일 재다운로드(?) 까지 고려하면 delFlag 사용이 정석인 느낌이라(제 개인적인 생각입니다...) 필드를 추가하긴 했으나.. 이미 resumeStatus 필드로 이력서 구분이 가능한데 쓸데없이 칼럼 추가에 메서드만(ResumeRepository > updateToDelete 참고) 더 만든 것 같다는 생각이 들기도 하네요!!!!!!관련해서 의견 주시면 무조건 감사합니다👊
