### PR TITLE
✨ [Feat] 이력서상태변경 기능추가,회원예외처리보완(#44)

### DIFF
--- a/src/main/java/com/devcv/admin/presentation/AdminController.java
+++ b/src/main/java/com/devcv/admin/presentation/AdminController.java
@@ -6,6 +6,8 @@ import com.devcv.auth.exception.JwtInvalidSignException;
 import com.devcv.common.exception.ErrorCode;
 import com.devcv.member.domain.dto.MemberLoginRequest;
 import com.devcv.member.domain.dto.MemberLoginResponse;
+import com.devcv.resume.application.ResumeService;
+import com.devcv.resume.domain.enumtype.ResumeStatus;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AuthService authService;
+    private final ResumeService resumeService;
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String AUTHORIZATION_REFRESH_HEADER = "RefreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
@@ -39,26 +42,9 @@ public class AdminController {
     }
     //----------- login end -----------
 
-    @GetMapping("/main")
-    public ResponseEntity<?> adminMain() {
-        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        System.out.println("/admin/main API RESPONSE");
-        return null;
-    }
-
-    @GetMapping("/resumes/{resumeId}")
-    public ResponseEntity<?> adminGetResume(@PathVariable Long resumeId, @AuthenticationPrincipal MemberDetails memberDetails) {
-        System.out.println("/admin/resumes/{resumeId} MemberDetails : " + memberDetails.getMember().getMemberId());
-        System.out.println("/admin/resumes/{resumeId} API RESPONSE");
-        System.out.println("/admin/resumes/{resumeId} resumeId : " + resumeId);
-        return null;
-    }
-
-    @PutMapping("/resumes/{resumeId}/status")
-    public ResponseEntity<?> adminResumeStatusUpdate(@PathVariable Long resumeId, @AuthenticationPrincipal UserDetails userDetails) {
-        System.out.println("/admin/{resumeId}/status UserDetails : " + userDetails.getUsername());
-        System.out.println("/admin/{resumeId}/status API RESPONSE");
-        System.out.println("/admin/{resumeId}/status resumeId : " + resumeId);
-        return null;
+    @PutMapping("/resumes/{resumeId}/{status}")
+    public ResponseEntity<?> adminUpdateResumeStatus(@PathVariable Long resumeId,@PathVariable ResumeStatus status) {
+        resumeService.updateStatus(resumeId, status);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/devcv/auth/application/AuthService.java
+++ b/src/main/java/com/devcv/auth/application/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(memberSignUpRequest.getSocial().name().equals(SocialType.normal.name()) ? memberSignUpRequest.getPassword() : socialPassword))
                 .nickName(memberSignUpRequest.getNickName()).phone(memberSignUpRequest.getPhone()).address(memberSignUpRequest.getAddress()).social(memberSignUpRequest.getSocial())
                 .company(memberSignUpRequest.getCompany()).job(memberSignUpRequest.getJob()).stack(memberSignUpRequest.getStack())
-                .memberRole(RoleType.admin)
+                .memberRole(RoleType.normal)
                 .build();
         try{
             if(member.getMemberName() == null || member.getNickName() == null || member.getEmail() == null

--- a/src/main/java/com/devcv/auth/application/AuthService.java
+++ b/src/main/java/com/devcv/auth/application/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(memberSignUpRequest.getSocial().name().equals(SocialType.normal.name()) ? memberSignUpRequest.getPassword() : socialPassword))
                 .nickName(memberSignUpRequest.getNickName()).phone(memberSignUpRequest.getPhone()).address(memberSignUpRequest.getAddress()).social(memberSignUpRequest.getSocial())
                 .company(memberSignUpRequest.getCompany()).job(memberSignUpRequest.getJob()).stack(memberSignUpRequest.getStack())
-                .memberRole(RoleType.normal)
+                .memberRole(RoleType.admin)
                 .build();
         try{
             if(member.getMemberName() == null || member.getNickName() == null || member.getEmail() == null

--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -7,6 +7,7 @@ import com.devcv.auth.filter.JwtFilter;
 import com.devcv.auth.jwt.JwtProvider;
 import com.devcv.member.domain.enumtype.RoleType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -29,8 +30,6 @@ public class SpringSecurityConfig {
     private final CorsFilter corsFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final MemberDetailsService memberDetailsService;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -1,16 +1,14 @@
 package com.devcv.auth.config;
 
-import com.devcv.auth.application.MemberDetailsService;
 import com.devcv.auth.filter.JwtAccessDeniedHandler;
 import com.devcv.auth.filter.JwtAuthenticationEntryPoint;
 import com.devcv.auth.filter.JwtFilter;
 import com.devcv.auth.jwt.JwtProvider;
 import com.devcv.member.domain.enumtype.RoleType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+//import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -62,8 +60,8 @@ public class SpringSecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .requestMatchers("/members/login","/members/signup","/members/find-id","/members/cert-email","/members/duplication-email",
-                        "/members/find-pw/email","/members/find-pw","/members/{memberid}/{password}","/admin/login",
-                         "/members/kakao-login","/members/google-login","/resumes","/resumes/{resumeId}", "/resumes/{resumeId}/reviews").permitAll()
+                        "/members/find-pw/email","/members/find-pw","/members/{member-id}/{password}","/admin/login",
+                         "/members/kakao-login","/members/google-login","/resumes","/resumes/{resume-id}", "/resumes/{resume-id}/reviews").permitAll()
 //                .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .requestMatchers("/admin/**").hasRole(RoleType.admin.name()) // 관리자 페이지
                 .anyRequest().authenticated()   // 이외 인증필요 -> Header에 "Bearer {accessToken}" 형태로 요청

--- a/src/main/java/com/devcv/member/application/MemberService.java
+++ b/src/main/java/com/devcv/member/application/MemberService.java
@@ -33,17 +33,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     public Member findMemberByEmail(String email) {
-        try {
-            Member findMember = memberRepository.findMemberByEmail(email);
-            if(findMember == null){
-                throw new NotSignUpException(ErrorCode.MEMBER_NOT_FOUND);
-            } else {
-                return findMember;
-            }
-        } catch (NotSignUpException e){
-            e.fillInStackTrace();
-            throw new NotSignUpException(ErrorCode.MEMBER_NOT_FOUND);
-        }
+       return memberRepository.findMemberByEmail(email);
     }
     public Member findMemberBymemberId(Long memberId) {
         try {

--- a/src/main/java/com/devcv/member/presentation/MemberController.java
+++ b/src/main/java/com/devcv/member/presentation/MemberController.java
@@ -261,10 +261,13 @@ public class MemberController {
                         throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
                     }
                 } else {
+                    HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
                     int resultUpdateSocialMember = memberService.updateSocialMemberBymemberId(memberModiAllRequest.getMemberName(),
                             memberModiAllRequest.getNickName(), memberModiAllRequest.getPhone(), memberModiAllRequest.getAddress(),
                             memberModiAllRequest.getCompany().name(), memberModiAllRequest.getJob().name(),
                             String.join(",", memberModiAllRequest.getStack()), memberId);
+                    memberLogRepository.save(MemberLog.builder().memberId(findMemberBymemberId.getMemberId()).logIp(getIp(request))
+                            .logEmail(findMemberBymemberId.getEmail()).logAgent(request.getHeader("user-agent")).logUpdateDate(LocalDateTime.now()).build());
                     if (resultUpdateSocialMember == 1) { // 소셜 멤버 수정성공.
                         return ResponseEntity.ok().build();
                     } else {

--- a/src/main/java/com/devcv/member/presentation/MemberController.java
+++ b/src/main/java/com/devcv/member/presentation/MemberController.java
@@ -171,8 +171,8 @@ public class MemberController {
 
     //----------- modi member start -----------
     // 비밀번호 변경 modipw
-    @PutMapping("/{memberId}/{password}")
-    public ResponseEntity<String> modiPassword(@PathVariable Long memberId, @PathVariable String password){
+    @PutMapping("/{member-id}/{password}")
+    public ResponseEntity<String> modiPassword(@PathVariable("member-id") Long memberId, @PathVariable String password){
         // NULL CHECK
         try {
             if(password == null || memberId == null){
@@ -211,8 +211,8 @@ public class MemberController {
         }
     }
     // 회원정보 단건 조회/수정
-    @PostMapping("{memberId}")
-    public ResponseEntity<MemberMypageResponse> getMember(@PathVariable Long memberId) {
+    @PostMapping("{member-id}")
+    public ResponseEntity<MemberMypageResponse> getMember(@PathVariable("member-id") Long memberId) {
         try {
             return ResponseEntity.ok().body(MemberMypageResponse.from(memberService.findMemberBymemberId(memberId)));
         } catch (NotSignUpException e){
@@ -220,8 +220,8 @@ public class MemberController {
             throw new NotSignUpException(ErrorCode.MEMBER_NOT_FOUND);
         }
     }
-    @PutMapping("/{memberId}")
-    public ResponseEntity<String> modiMember(@RequestBody MemberModiAllRequest memberModiAllRequest, @PathVariable Long memberId) {
+    @PutMapping("/{member-id}")
+    public ResponseEntity<String> modiMember(@RequestBody MemberModiAllRequest memberModiAllRequest, @PathVariable("member-id") Long memberId) {
         // NULL CHECK
         try {
             if(memberModiAllRequest.getJob() == null || memberModiAllRequest.getAddress() == null || memberModiAllRequest.getStack() == null

--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -6,6 +6,7 @@ import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeListResponse;
 import com.devcv.resume.domain.dto.ResumeRequest;
 import com.devcv.resume.domain.enumtype.CompanyType;
+import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.domain.enumtype.StackType;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,6 +32,8 @@ public interface ResumeService {
     Resume findByResumeId(Long resumeId);
     // 이력서 등록 수정
     ResumeDto modify(Long resumeId, Long memberId, ResumeDto resumeDto, MultipartFile resumeFile, List<MultipartFile> images);
+
+    int updateStatus(Long resumeId, ResumeStatus resumeStatus);
     // 이력서 삭제
     Resume remove(Long resumeId, Long memberId);
 }

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -345,4 +345,9 @@ public class ResumeServiceImpl implements ResumeService {
             throw new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND);
         }
     }
+
+    @Override
+    public int updateStatus(Long resumeId, ResumeStatus resumeStatus) {
+        return resumeRepository.updateByresumeId(resumeId,resumeStatus);
+    }
 }

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -86,5 +86,7 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     @Query("UPDATE Resume r set r.delFlag = :flag where r.resumeId = :resumeId")
     void updateToDelete(Long resumeId, boolean flag);
 
-
+    @Modifying
+    @Query("UPDATE Resume r set r.status = :status where r.resumeId = :resumeId")
+    int updateByresumeId(Long resumeId, ResumeStatus status);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44 
## 📝작업 내용

- 관리자 이력서 상태수정기능추가 -> Resume Repository, Service 기능에 대한 메서드 추가
- 회원정보수정 메서드 부분.
:  Service단에서 findMemberByEmail 예외처리에서 다시 Controller 단 예외처리로 변경,, 
(재사용성이 아쉬워서 다시 바꿔보았습니다,,)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 