### PR TITLE
✨ [Feat] 이력서 판매등록 예외처리 보완, endpoint 수정 (#60)

### DIFF
--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     INSUFFICIENT_POINT("보유 포인트가 부족합니다."),
     NOT_ONGOING_EVENT("이벤트 진행 기간이 아닙니다."),
     ALREADY_ATTENDED_EVENT("이미 참석한 이벤트입니다."),
+    FILE_SIZE_LIMIT_EXCEEDED("파일 크기 제한(20MB)을 초과했습니다."),
+    FILE_NAME_LENGTH_EXCEEDED("파일 이름 길이 제한(50자)을 초과했습니다."),
 
     //401
     UNAUTHORIZED_ERROR("자격증명에 실패하였습니다."),
@@ -48,7 +50,7 @@ public enum ErrorCode {
     IO_EXCEPTION_ON_IMAGE_UPLOAD("이미지 업로드 중 IO 예외가 발생했습니다."),
     PUT_OBJECT_EXCEPTION("S3에 객체를 저장하는 중 예외가 발생했습니다."),
     INTERNAL_SERVER_ERROR("서버 내부에 문제가 발생했습니다."),
-    UNAUTHORIZED_TO_COMPLETE_REGISTRATION("이력서 등록 완료 권한이 없습니다."),
+    RESUME_NOT_APPROVAL("이력서가 승인대기 상태입니다"),
     TEST_ERROR("테스트용 에러입니다."),
     ;
 

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -6,10 +6,7 @@ import com.devcv.auth.exception.JwtInvalidSignException;
 import com.devcv.auth.exception.JwtUnsupportedException;
 import com.devcv.common.exception.dto.ErrorResponse;
 import com.devcv.member.exception.*;
-import com.devcv.resume.exception.MemberNotFoundException;
-import com.devcv.resume.exception.ResumeNotExistException;
-import com.devcv.resume.exception.ResumeNotFoundException;
-import com.devcv.resume.exception.S3Exception;
+import com.devcv.resume.exception.*;
 import com.devcv.member.exception.AuthLoginException;
 import com.devcv.member.exception.DuplicationException;
 import com.devcv.member.exception.NotNullException;
@@ -24,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
 
 
 @Slf4j
@@ -43,6 +41,13 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.from(ErrorCode.TEST_ERROR));
+    }
+
+    @ExceptionHandler(ResumeStatusException.class)
+    public ResponseEntity<ErrorResponse> handle(ResumeStatusException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.from(ErrorCode.RESUME_NOT_APPROVAL));
     }
     // 500 end
 
@@ -190,6 +195,21 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(e));
     }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handle(MultipartException e) {
+        log.error(e.getMessage());
+        return  ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ErrorCode.FILE_SIZE_LIMIT_EXCEEDED));
+    }
+
+    @ExceptionHandler(FileNameLengthExceededException.class)
+    public ResponseEntity<ErrorResponse> handle(FileNameLengthExceededException e) {
+        log.error(e.getMessage());
+        return  ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ErrorCode.FILE_NAME_LENGTH_EXCEEDED));
+    }
+
     // 400 end
 
 

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -11,10 +11,7 @@ import com.devcv.resume.domain.dto.*;
 import com.devcv.resume.domain.enumtype.CompanyType;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.domain.enumtype.StackType;
-import com.devcv.resume.exception.HttpMessageNotReadableException;
-import com.devcv.resume.exception.MemberNotFoundException;
-import com.devcv.resume.exception.ResumeNotExistException;
-import com.devcv.resume.exception.ResumeNotFoundException;
+import com.devcv.resume.exception.*;
 import com.devcv.resume.infrastructure.S3Uploader;
 import com.devcv.resume.repository.CategoryRepository;
 import com.devcv.resume.repository.ResumeRepository;
@@ -44,6 +41,9 @@ public class ResumeServiceImpl implements ResumeService {
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
     private final S3Uploader s3Uploader;
+
+    // 최대 이미지 파일 크기, 20MB
+    private static final long MAX_IMAGE_SIZE = 20 * 1024 * 1024;
 
 
     // 이력서 목록 조회
@@ -212,6 +212,9 @@ public class ResumeServiceImpl implements ResumeService {
         Optional<Resume> resumeOpt = resumeRepository.findByIdAndMemberId(resumeId, memberId);
         if (resumeOpt.isPresent()) {
             Resume resume = resumeOpt.get();
+            if (resume.getStatus() == ResumeStatus.승인대기) {
+                throw new ResumeStatusException(ErrorCode.RESUME_NOT_APPROVAL);
+            }
             if (resume.getStatus() == ResumeStatus.삭제) {
                 throw new ResumeNotExistException(ErrorCode.RESUME_NOT_EXIST);
             }

--- a/src/main/java/com/devcv/resume/domain/Resume.java
+++ b/src/main/java/com/devcv/resume/domain/Resume.java
@@ -31,7 +31,7 @@ public class Resume extends BaseTimeEntity{
     private String title;
     @Column(nullable = false)
     private String content;
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1024)
     private String resumeFilePath;
     @Column(nullable = false)
     private boolean delFlag;

--- a/src/main/java/com/devcv/resume/domain/ResumeImage.java
+++ b/src/main/java/com/devcv/resume/domain/ResumeImage.java
@@ -1,5 +1,6 @@
 package com.devcv.resume.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
@@ -12,6 +13,7 @@ import lombok.*;
 public class ResumeImage {
 
     // S3URL
+    @Column(nullable = false, length = 1024)
     private String resumeImgPath;
     // 썸네일 이미지 번호 설정
     private int ord;

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeDto.java
@@ -26,6 +26,7 @@ public class ResumeDto {
     private CategoryDto category;
     private Long memberId;
     private String sellerNickname;
+    private String sellerEmail;
 
     // 평균 별점, 구매후기 개수 필드 추가
     private Double averageGrade;
@@ -44,6 +45,7 @@ public class ResumeDto {
                 CategoryDto.from(resume.getCategory()),
                 resume.getMember().getMemberId(),
                 resume.getMember().getNickName(),
+                resume.getMember().getEmail(),
                 null,
                 null
         );
@@ -60,6 +62,7 @@ public class ResumeDto {
                 .stack(resume.getStack())
                 .memberId(resume.getMember().getMemberId())
                 .sellerNickname(resume.getMember().getNickName())
+                .sellerEmail(resume.getMember().getEmail())
                 .imageList(resume.getImageList())
                 .category(CategoryDto.from(resume.getCategory()))
                 .build();

--- a/src/main/java/com/devcv/resume/exception/FileNameLengthExceededException.java
+++ b/src/main/java/com/devcv/resume/exception/FileNameLengthExceededException.java
@@ -1,0 +1,11 @@
+package com.devcv.resume.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class FileNameLengthExceededException extends CustomException {
+
+    public FileNameLengthExceededException(ErrorCode errorCode) {super(errorCode);}
+
+    public FileNameLengthExceededException(ErrorCode errorCode, String message) {super(errorCode, message);}
+}

--- a/src/main/java/com/devcv/resume/exception/MultipartException.java
+++ b/src/main/java/com/devcv/resume/exception/MultipartException.java
@@ -1,0 +1,11 @@
+package com.devcv.resume.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class MultipartException extends CustomException {
+
+    public MultipartException(ErrorCode errorCode) {super(errorCode);}
+
+    public MultipartException(ErrorCode errorCode, String message) {super(errorCode, message);}
+}

--- a/src/main/java/com/devcv/resume/exception/ResumeStatusException.java
+++ b/src/main/java/com/devcv/resume/exception/ResumeStatusException.java
@@ -1,0 +1,11 @@
+package com.devcv.resume.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class ResumeStatusException extends CustomException {
+
+    public ResumeStatusException(ErrorCode errorCode) {super(errorCode);}
+
+    public ResumeStatusException(ErrorCode errorCode, String message) {super(errorCode, message);}
+}

--- a/src/main/java/com/devcv/resume/infrastructure/S3Uploader.java
+++ b/src/main/java/com/devcv/resume/infrastructure/S3Uploader.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.devcv.common.exception.ErrorCode;
+import com.devcv.resume.exception.FileNameLengthExceededException;
 import com.devcv.resume.exception.S3Exception;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,11 +31,17 @@ public class S3Uploader {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    // 최대 파일 제목 길이, 50자
+    private static final int MAX_FILE_NAME_LENGTH = 50;
+
     //외부 호출 가능 메서드
     public String upload(MultipartFile image) {
         //입력받은 이미지 파일이 빈 파일인지 검증
         if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())){
             throw new S3Exception(ErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        if (image.getOriginalFilename().length() > MAX_FILE_NAME_LENGTH) {
+            throw new FileNameLengthExceededException(ErrorCode.FILE_NAME_LENGTH_EXCEEDED);
         }
         //uploadImage 호출
         return this.uploadImage(image);

--- a/src/main/java/com/devcv/resume/presentation/ResumeController.java
+++ b/src/main/java/com/devcv/resume/presentation/ResumeController.java
@@ -26,17 +26,16 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/resumes")
 public class ResumeController {
 
     private final ResumeService resumeService;
 
     //------------이력서 목록 조회 요청 start---------------
-    @GetMapping()
+    @GetMapping("/resumes")
     public ResponseEntity<PaginatedResumeResponse> getResumesByConditions(
             @RequestParam("page") int page, @RequestParam("size") int size,
-            @RequestParam(value = "stackType", required = false) StackType stackType,
-            @RequestParam(value = "companyType", required = false) CompanyType companyType) {
+            @RequestParam(value = "stack-type", required = false) StackType stackType,
+            @RequestParam(value = "company-type", required = false) CompanyType companyType) {
 
         try {
             PaginatedResumeResponse response = resumeService.findResumes(stackType, companyType, page, size);
@@ -49,7 +48,7 @@ public class ResumeController {
 
 
     //------------이력서 상세 조회 요청 start--------------
-    @GetMapping("/{resume-id}")
+    @GetMapping("resumes/{resume-id}")
     public ResponseEntity<ResumeDto> getResumeDetail(@PathVariable("resume-id") Long resumeId) {
         try {
             ResumeDto resumeDetail = resumeService.getResumeDetail(resumeId);
@@ -63,7 +62,7 @@ public class ResumeController {
 
 
     // -------이력서 승인대기 요청 start-------------
-    @PostMapping()
+    @PostMapping("/resumes")
     public ResponseEntity<ResumeDto> registerResume(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestPart("resume") ResumeRequest resumeRequest,
@@ -84,7 +83,7 @@ public class ResumeController {
 
 
     //----------이력서 판매 상세 내역 페이지 호출 start---------
-    @GetMapping("/myresume/{resume-id}")
+    @GetMapping("/members/{member-id}/resumes/{resume-id}")
     public ResponseEntity<?> getResumeForEdit(
             @AuthenticationPrincipal UserDetails userDetails, @PathVariable("resume-id") Long resumeId) {
         if(userDetails == null) {
@@ -104,7 +103,7 @@ public class ResumeController {
 
 
     //----------이력서 판매 등록 요청 start----------------
-    @PutMapping("/myresume/{resume-id}/status")
+    @PutMapping("/members/{member-id}/resumes/{resume-id}/status")
     public ResponseEntity<?> completeResumeRegistration(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("resume-id") Long resumeId) {
@@ -120,7 +119,7 @@ public class ResumeController {
 
 
     // ----------이력서 수정 등록 요청 start----------------
-    @PutMapping("/{resume-id}")
+    @PutMapping("/members/{member-id}/resumes/{resume-id}")
     public ResponseEntity<ResumeDto> modifyResume(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable ("resume-id") Long resumeId,
@@ -141,7 +140,7 @@ public class ResumeController {
 
 
     // ----------이력서 삭제 등록 요청 start----------------
-    @DeleteMapping("/{resume-id}")
+    @DeleteMapping("/members/{member-id}/resumes/{resume-id}")
     public  Map<String, Object> removeResume(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("resume-id") Long resumeId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60 
## 📝작업 내용

1. Resume, ResumeImage 엔티티 길이값 수정
2.  파일 업로드 시 크기 및 제목 길이 예외처리 추가
3. 판매등록 요청 시 "승인대기" 상태 예외처리 추가
4. 이력서 상세페이지 조회 시 판매자 이메일 응답값 정보 추가
5.  ResumeController endpoint RESTful 원칙에 따른 일괄 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

**1. Resume, ResumeImage 엔티티 길이값 수정**

  -> 오늘 스크럼 때 이력서 등록 쪽에서 계속 발생했던 오류에 대해 찾아보니.. 파일 업로드 시 uuid로 변환되는 과정에서 파일 제목이 한글 + 길이가 길면 변환될 때 무자비하게 path명이 길어지며....varchar(255)로 지정된 길이를 넘어 insert가 안되는 오류더군요...
  이렇게 되면 S3Config 쪽 uuid 변환 방식을 뜯어 고쳐야 하는데.. 이건 리팩토링 기간 때 수정해보는 걸로 하겠습니다.,,,,
  
  따라서‼️
  1. SQL 스키마 변경 (기존 varchar(255) -> varchar(1024) 수정) 
  -> 이건 현재 devcv-dev db에 alter문 돌려서 업데이트 된 상태입니다
  
  2. Jpa Entity length 값 변경( 아래 사진 참고)
  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/96553cc2-0d08-4893-a37a-eafa36bdc292)
  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/4be3a73c-d5af-4175-9902-03093e730dac)
  -> 이렇게 두가지 방법 적용해서 해결했습니다...네...😂
  
  
  ---------------
  **2. 파일 업로드 시 크기 및 제목 길이 예외처리 추가**

앞에 1번 해결하면서 놓쳤던 예외처리 추가했습니다.

    1. 파일 업로드 크기 제한(20MB) - MultipartException.class
    2. 파일 제목 길이 제한(50자 제한) -FileNameLengthExceededException.class

----------------
**3. 판매등록 요청 시 "승인대기" 상태 예외처리 추가**
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/52c66e1e-2344-472d-bfcd-68a0a55ae04c)

-> 다음과 같이 "승인대기" 상태인 이력서로 "등록완료" 요청 시 발생하는 예외처리 추가했습니다

**4. 이력서 상세페이지 조회 시 판매자 이메일 정보 응답값 추가**
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/22b7e24c-6e4a-425f-a4ec-24b1073133aa)
 -> 다음과 같이 ResumeDto에 sellerEmail 필드 추가하여 이력서 상세 페이지에서 조회가 가능합니다.