### PR TITLE
✨ [Feat] 이력서 구매후기 조회 기능 수정 (#71)

### DIFF
--- a/src/main/java/com/devcv/review/application/ReviewService.java
+++ b/src/main/java/com/devcv/review/application/ReviewService.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public interface ReviewService {
 
     // 이력서의 모든 구매후기 조회
-    PaginatedReviewResponse getListOfResume(Long resumeId, int page, int  size);
+    PaginatedReviewResponse getListOfResume(Long resumeId, int page, int  size, String sort);
 
     // 이력서 구매후기 등록
     Review register(Long resumeId, Long memberId, ReviewDto resumeReviewDto);
@@ -54,6 +54,7 @@ public interface ReviewService {
                 .orderId(resumeReview.getOrder().getOrderId())
                 .reviewerNickname(resumeReview.getMember().getNickName())
                 .sellerNickname(resumeReview.getResume().getMember().getNickName())
+                .sellerEmail(resumeReview.getResume().getMember().getEmail())
                 .grade(resumeReview.getGrade())
                 .text(resumeReview.getText())
                 .createdDate(resumeReview.getCreatedDate())

--- a/src/main/java/com/devcv/review/domain/dto/PaginatedReviewResponse.java
+++ b/src/main/java/com/devcv/review/domain/dto/PaginatedReviewResponse.java
@@ -23,6 +23,7 @@ public class PaginatedReviewResponse {
     private int endPage;
 
     private long totalReviews;
-    private Double averageRating;
+    private int averageRating;
+    private Long[] ratingCounts;
 
 }

--- a/src/main/java/com/devcv/review/domain/dto/ReviewDto.java
+++ b/src/main/java/com/devcv/review/domain/dto/ReviewDto.java
@@ -21,6 +21,7 @@ public class ReviewDto {
     private Long resumeId;
 
     private Long memberId;
+    private String reviewerNickname;
 
     private String orderId;
 
@@ -30,8 +31,8 @@ public class ReviewDto {
 
     private LocalDateTime createdDate, updatedDate;
 
-    private String reviewerNickname;
     private String sellerNickname;
+    private String sellerEmail;
 
     private List<CommentDto> commentDtoList;
 
@@ -43,6 +44,7 @@ public class ReviewDto {
                 .orderId(review.getOrder().getOrderId())
                 .reviewerNickname(review.getMember().getNickName())
                 .sellerNickname(review.getResume().getMember().getNickName())
+                .sellerEmail(review.getResume().getMember().getEmail())
                 .grade(review.getGrade())
                 .text(review.getText())
                 .createdDate(review.getCreatedDate())

--- a/src/main/java/com/devcv/review/presentation/ReviewController.java
+++ b/src/main/java/com/devcv/review/presentation/ReviewController.java
@@ -30,10 +30,11 @@ public class ReviewController {
     @GetMapping("/{resume-id}/reviews")
     public ResponseEntity<PaginatedReviewResponse> getList(
             @RequestParam("page") int page, @RequestParam("size") int size,
+            @RequestParam(value = "sort", defaultValue = "d-desc") String sort,
             @PathVariable("resume-id") Long resumeId) {
 
         try {
-            PaginatedReviewResponse response = reviewService.getListOfResume(resumeId, page, size);
+            PaginatedReviewResponse response = reviewService.getListOfResume(resumeId, page, size, sort);
             return ResponseEntity.ok(response);
         } catch (InternalServerException e) {
             throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/devcv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/devcv/review/repository/ReviewRepository.java
@@ -18,8 +18,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Long countByResumeId(Long resumeId);
 
     // 평균 별점 조회
-    @Query("SELECT AVG(r.grade) FROM Review r WHERE r.resume.resumeId = :resumeId")
-    Double calculateAverageGrade(Long resumeId);
+    @Query("SELECT COALESCE(AVG(r.grade), 0) FROM Review r WHERE r.resume.resumeId = :resumeId")
+    int calculateAverageGrade(Long resumeId);
 
     // 특정 이력서 모든 리뷰 확인
     @EntityGraph(attributePaths = {"member", "order"}, type=EntityGraph.EntityGraphType.FETCH)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

1. 이력서 구매후기 별점 별 개수 조회 기능 추가
2. 별점 평균 값 데이터 타입 수정(수정 전:  double -> 수정 후 int )
3. 구매후기 최신순, 평점 높은순, 평점 낮은순 조회 기능 추가
4. 이력서 구매후기 조회 시 판매자 이메일 응답값 정보 추가


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

1. 이력서 구매후기 별점 별 개수 조회 기능 추가
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/e64e7349-6c20-415c-8300-fb20399bb175)
-> ReviewPaginatedResponse에 담아 전송하고, 주환님이 배열 타입으로 받는게 편하다고 하셔서 배열로 진행했습니다
---------

3. 구매후기 최신순, 평점 높은순, 평점 낮은순 조회 기능 추가
-> RequestParam으로 받아서 들어오는 sort 값에 따라 Pageable 객체에 담겨 findById에 따라 조회됩니다!

  - 기본 = 최신순

  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/ab5741a4-2c6d-49cf-a26d-2e8b69ca95c8)
  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/8dadce4c-5366-482c-b4c2-eaac0c802a5d)
  -> 두개 모두 동일하게 최신순으로 출력됩니다

  - 평점 높은순

  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/994ef751-c5c0-4c91-b3d2-b526a7a6f244)

  - 평점 낮은순

  ![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/fd285131-b65d-403b-ad5e-364fb5514094)

---------

4. 이력서 구매후기 조회 시 판매자 이메일 응답값 정보 추가

-> 흠 이건.. 원래 상세페이지 쪽에서 주환님이 요청하셨는데 혹시 몰라 추가했습니다..