### PR TITLE
✨ [Feat] 관리자 이력서 관리 기능 수정 (#85)

### DIFF
--- a/src/main/java/com/devcv/admin/application/AdminService.java
+++ b/src/main/java/com/devcv/admin/application/AdminService.java
@@ -1,43 +1,84 @@
 package com.devcv.admin.application;
 
 import com.devcv.admin.dto.AdminResumeList;
+import com.devcv.admin.dto.PaginatedAdminResumeResponse;
 import com.devcv.admin.repository.AdminResumeRepository;
+import com.devcv.common.exception.BadRequestException;
 import com.devcv.common.exception.ErrorCode;
 import com.devcv.common.exception.NotFoundException;
 import com.devcv.event.domain.Event;
 import com.devcv.event.domain.dto.EventRequest;
 import com.devcv.event.repository.EventRepository;
 import com.devcv.resume.domain.Resume;
+import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeResponse;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
+import com.devcv.resume.exception.ResumeNotExistException;
+import com.devcv.resume.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AdminService {
 
     private final EventRepository eventRepository;
     private final AdminResumeRepository adminResumeRepository;
+    private final ResumeRepository resumeRepository;
 
     public Event createEvent(EventRequest eventRequest) {
         Event event = Event.of(eventRequest.name(), eventRequest.startDate(), eventRequest.endDate());
         return eventRepository.save(event);
     }
 
-    public AdminResumeList getResumesByStatus(String input) {
+    public PaginatedAdminResumeResponse getResumesByStatus(String input, int page, int size) {
         ResumeStatus status = ResumeStatus.valueOf(input);
-        List<ResumeResponse> resumeList = adminResumeRepository.findByStatus(status)
-                .stream().map(ResumeResponse::from).toList();
-        int count = resumeList.size();
-        return AdminResumeList.of(status, count, resumeList);
+        Pageable pageable = PageRequest.of(page-1, size);
+        Page<Resume> resumePage = adminResumeRepository.findByStatus(status, pageable);
+        List<ResumeResponse> resumeList = resumePage.getContent().stream().map(ResumeResponse::from).collect(Collectors.toList());
+        AdminResumeList adminResumeList = AdminResumeList.of(status , resumeList);
+        return new PaginatedAdminResumeResponse(
+                List.of(adminResumeList),
+                resumePage.getTotalElements(),
+                resumePage.getNumberOfElements(),
+                resumePage.getNumber()+1,
+                resumePage.getTotalPages(),
+                resumePage.getSize(),
+                page,
+                resumePage.getTotalPages()
+        );
     }
 
-    public ResumeResponse getResume(Long resumeId) {
+    public ResumeDto getResume(Long resumeId) {
         Resume resume = adminResumeRepository.findByResumeId(resumeId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.RESUME_NOT_FOUND));
-        return ResumeResponse.from(resume);
+        return ResumeDto.from(resume);
+    }
+
+    // 상태 변경
+    // resumeStatus에 가능한 값 : approved, rejected
+    public int updateStatus(Long resumeId, ResumeStatus resumeStatus) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.RESUME_NOT_FOUND));
+
+        // 예외 처리 추가
+        // regcompleted, modified 접근 불가
+        if (resume.getStatus() == ResumeStatus.regcompleted
+                || resumeStatus == ResumeStatus.modified || resumeStatus == ResumeStatus.regcompleted) {
+            throw new BadRequestException(ErrorCode.RESUME_STATUS_EXCEPTION);
+        }
+        // deleted 접근 불가
+        if (resume.getStatus() == ResumeStatus.deleted || resumeStatus == ResumeStatus.deleted) {
+            throw new ResumeNotExistException(ErrorCode.RESUME_NOT_EXIST);
+        }
+        return adminResumeRepository.updateByresumeId(resumeId,resumeStatus);
     }
 }

--- a/src/main/java/com/devcv/admin/dto/AdminResumeList.java
+++ b/src/main/java/com/devcv/admin/dto/AdminResumeList.java
@@ -5,9 +5,9 @@ import com.devcv.resume.domain.enumtype.ResumeStatus;
 
 import java.util.List;
 
-public record AdminResumeList(ResumeStatus status, int count, List<ResumeResponse> resumeList) {
+public record AdminResumeList(ResumeStatus status, List<ResumeResponse> resumeList) {
 
-    public static AdminResumeList of(ResumeStatus status, int count, List<ResumeResponse> resumeList) {
-        return new AdminResumeList(status, count, resumeList);
+    public static AdminResumeList of(ResumeStatus status, List<ResumeResponse> resumeList) {
+        return new AdminResumeList(status, resumeList);
     }
 }

--- a/src/main/java/com/devcv/admin/dto/PaginatedAdminResumeResponse.java
+++ b/src/main/java/com/devcv/admin/dto/PaginatedAdminResumeResponse.java
@@ -1,0 +1,27 @@
+package com.devcv.admin.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaginatedAdminResumeResponse {
+
+    private List<AdminResumeList> content;
+    private Long totalElements;
+    private int numberOfElements;
+    private int currentPage;
+    private int totalPages;
+    private int size;
+    private int startPage;
+    private int endPage;
+
+}
+

--- a/src/main/java/com/devcv/admin/presentation/AdminController.java
+++ b/src/main/java/com/devcv/admin/presentation/AdminController.java
@@ -2,14 +2,17 @@ package com.devcv.admin.presentation;
 
 import com.devcv.admin.application.AdminService;
 import com.devcv.admin.dto.AdminResumeList;
+import com.devcv.admin.dto.PaginatedAdminResumeResponse;
 import com.devcv.auth.application.AuthService;
 import com.devcv.auth.exception.JwtInvalidSignException;
+import com.devcv.common.exception.BadRequestException;
 import com.devcv.common.exception.ErrorCode;
 import com.devcv.event.domain.Event;
 import com.devcv.event.domain.dto.EventRequest;
 import com.devcv.member.domain.dto.MemberLoginRequest;
 import com.devcv.member.domain.dto.MemberLoginResponse;
 import com.devcv.resume.application.ResumeService;
+import com.devcv.resume.domain.dto.ResumeDto;
 import com.devcv.resume.domain.dto.ResumeResponse;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
 import lombok.AllArgsConstructor;
@@ -27,22 +30,35 @@ public class AdminController {
     private final ResumeService resumeService;
     private final AdminService adminService;
 
+    // 이력서 상태 변경
     @PatchMapping("/resumes/{resumeId}/{status}")
-    public ResponseEntity<String> adminUpdateResumeStatus(@PathVariable Long resumeId,@PathVariable ResumeStatus status) {
-        resumeService.updateStatus(resumeId, status);
+    public ResponseEntity<String> adminUpdateResumeStatus(@PathVariable Long resumeId,@PathVariable ResumeStatus status)
+    {
+        adminService.updateStatus(resumeId, status);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/resumes")
-    public ResponseEntity<AdminResumeList> getAdminResumes(@RequestParam("status") String status) {
-        AdminResumeList adminResumeList = adminService.getResumesByStatus(status);
-        return ResponseEntity.ok(adminResumeList);
+    @GetMapping("/resumes/pending")
+    public ResponseEntity<PaginatedAdminResumeResponse> getPendingResumes(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size) {
+        PaginatedAdminResumeResponse pendingResumes = adminService.getResumesByStatus("pending", page, size);
+        return ResponseEntity.ok(pendingResumes);
     }
 
+    @GetMapping("/resumes/modified")
+    public ResponseEntity<PaginatedAdminResumeResponse> getModifiedResumes(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size) {
+        PaginatedAdminResumeResponse modifiedResumes = adminService.getResumesByStatus("modified", page, size);
+        return ResponseEntity.ok(modifiedResumes);
+    }
+
+    // 이력서 상세 조회
     @GetMapping("/resumes/{resume-id}")
-    public ResponseEntity<ResumeResponse> getAdminResumes(@PathVariable("resume-id") Long resumeId) {
-        ResumeResponse resumeResponse = adminService.getResume(resumeId);
-        return ResponseEntity.ok(resumeResponse);
+    public ResponseEntity<ResumeDto> getAdminResumes(@PathVariable("resume-id") Long resumeId) {
+        ResumeDto adminResumeDto= adminService.getResume(resumeId);
+        return ResponseEntity.ok(adminResumeDto);
     }
 
     @PostMapping("/events")

--- a/src/main/java/com/devcv/admin/repository/AdminResumeRepository.java
+++ b/src/main/java/com/devcv/admin/repository/AdminResumeRepository.java
@@ -2,8 +2,11 @@ package com.devcv.admin.repository;
 
 import com.devcv.resume.domain.Resume;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -11,11 +14,15 @@ import java.util.Optional;
 
 public interface AdminResumeRepository extends JpaRepository<Resume, Long> {
 
-    @EntityGraph(attributePaths = {"member", "category"}, type=EntityGraph.EntityGraphType.FETCH)
-    @Query("SELECT r FROM Resume r JOIN FETCH r.imageList WHERE r.status = ?1 ORDER BY r.createdDate ASC")
-    List<Resume> findByStatus(ResumeStatus status);
+    @EntityGraph(attributePaths = {"member", "category", "imageList"}, type = EntityGraph.EntityGraphType.FETCH)
+    @Query("SELECT r FROM Resume r WHERE r.status = :status ORDER BY r.createdDate ASC")
+    Page<Resume> findByStatus(ResumeStatus status, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member", "category"}, type=EntityGraph.EntityGraphType.FETCH)
     @Query("SELECT r FROM Resume r JOIN FETCH r.imageList WHERE r.resumeId = ?1")
     Optional<Resume> findByResumeId(Long resumeId);
+
+    @Modifying
+    @Query("UPDATE Resume r set r.status = :status where r.resumeId = :resumeId")
+    int updateByresumeId(Long resumeId, ResumeStatus status);
 }

--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -32,8 +32,6 @@ public interface ResumeService {
     Resume findByResumeId(Long resumeId);
     // 이력서 등록 수정
     ResumeDto modify(Long resumeId, Long memberId, ResumeDto resumeDto, MultipartFile resumeFile, List<MultipartFile> images);
-
-    int updateStatus(Long resumeId, ResumeStatus resumeStatus);
     // 이력서 삭제
     Resume remove(Long resumeId, Long memberId);
 }

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -222,7 +222,7 @@ public class ResumeServiceImpl implements ResumeService {
         Optional<Resume> resumeOpt = resumeRepository.findByIdAndMemberId(resumeId, memberId);
         if (resumeOpt.isPresent()) {
             Resume resume = resumeOpt.get();
-            if (resume.getStatus() == ResumeStatus.pending) {
+            if (resume.getStatus() == ResumeStatus.pending || resume.getStatus() == ResumeStatus.modified) {
                 throw new ResumeStatusException(ErrorCode.RESUME_NOT_APPROVAL);
             }
             if (resume.getStatus() == ResumeStatus.deleted) {
@@ -270,7 +270,7 @@ public class ResumeServiceImpl implements ResumeService {
             resume.changeContent(resumeDto.getContent());
             resume.changePrice(resumeDto.getPrice());
             resume.changeStack(resumeDto.getStack());
-            resume.setStatus(ResumeStatus.pending);
+            resume.setStatus(ResumeStatus.modified);
 
 
             // 현재 상태를 로그로 저장
@@ -361,11 +361,5 @@ public class ResumeServiceImpl implements ResumeService {
         } else {
             throw new ResumeNotFoundException(ErrorCode.RESUME_NOT_FOUND);
         }
-    }
-
-    @Override
-    public int updateStatus(Long resumeId, ResumeStatus resumeStatus) {
-        saveResumeLog(findByResumeId(resumeId), resumeStatus);
-        return resumeRepository.updateByresumeId(resumeId,resumeStatus);
     }
 }

--- a/src/main/java/com/devcv/resume/domain/enumtype/ResumeStatus.java
+++ b/src/main/java/com/devcv/resume/domain/enumtype/ResumeStatus.java
@@ -1,5 +1,5 @@
 package com.devcv.resume.domain.enumtype;
 
 public enum ResumeStatus {
-    pending, approved, regcompleted, deleted, rejected
+    pending, approved, regcompleted, deleted, modified, rejected
 }

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -86,7 +86,4 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     @Query("UPDATE Resume r set r.delFlag = :flag where r.resumeId = :resumeId")
     void updateToDelete(Long resumeId, boolean flag);
 
-    @Modifying
-    @Query("UPDATE Resume r set r.status = :status where r.resumeId = :resumeId")
-    int updateByresumeId(Long resumeId, ResumeStatus status);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#85 

## 📝 작업 내용

1.   resumeStatus.modified (수정) 상태 추가
2.  승인대기 신청 이력서 조회, 수정 신청 이력서 조회 API 분리 
3.  승인대기, 수정 신청 이력서 목록 페이지네이션 추가
4.  관리자 이력서 상태변경(approved, rejected) 값 추가
5.  관리자 이력서 상태변경 API 예외처리 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
