### PR TITLE
✨ [Feat] RefreshToken Cookie에 담아 전송(#84)

### DIFF
--- a/src/main/java/com/devcv/auth/config/JwtSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/JwtSecurityConfig.java
@@ -3,11 +3,13 @@ package com.devcv.auth.config;
 import com.devcv.auth.filter.JwtFilter;
 import com.devcv.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@Configuration
 @RequiredArgsConstructor
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
     private final JwtProvider jwtProvider;

--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -2,7 +2,6 @@ package com.devcv.auth.config;
 
 import com.devcv.auth.filter.JwtAccessDeniedHandler;
 import com.devcv.auth.filter.JwtAuthenticationEntryPoint;
-import com.devcv.auth.filter.JwtFilter;
 import com.devcv.auth.jwt.JwtProvider;
 import com.devcv.member.domain.enumtype.RoleType;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +57,7 @@ public class SpringSecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .requestMatchers("/members/login","/members/signup","/members/find-id","/members/cert-email","/members/duplication-email",
-                        "/members/find-pw/email","/members/find-pw","/members/{member-id}/password","/admin/login",
+                        "/members/find-pw/email","/members/find-pw","/members/{member-id}/password","/admin/login","/members/refresh-token",
                          "/members/kakao-login","/members/google-login","/resumes","/resumes/{resume-id}", "/resumes/{resume-id}/reviews").permitAll()
 //                .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .requestMatchers("/admin/**").hasRole(RoleType.admin.name()) // 관리자 페이지

--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -23,7 +23,6 @@ import org.springframework.web.filter.CorsFilter;
 @RequiredArgsConstructor
 public class SpringSecurityConfig {
 
-    private final JwtFilter jwtFilter;
     private final JwtProvider jwtProvider;
     private final CorsFilter corsFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -40,7 +39,6 @@ public class SpringSecurityConfig {
         http.csrf().disable()
                 // CORS 설정
                 .addFilterBefore(corsFilter, CorsFilter.class)
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 // exception handling
                 .exceptionHandling()
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/devcv/auth/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/devcv/auth/dto/RefreshTokenResponse.java
@@ -1,0 +1,10 @@
+package com.devcv.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class RefreshTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/devcv/auth/exception/JwtNotExpiredException.java
+++ b/src/main/java/com/devcv/auth/exception/JwtNotExpiredException.java
@@ -1,0 +1,12 @@
+package com.devcv.auth.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class JwtNotExpiredException extends CustomException {
+    public JwtNotExpiredException(ErrorCode errorCode) { super(errorCode); }
+
+    public JwtNotExpiredException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/devcv/auth/exception/JwtNotFoundRefreshTokenException.java
+++ b/src/main/java/com/devcv/auth/exception/JwtNotFoundRefreshTokenException.java
@@ -1,0 +1,12 @@
+package com.devcv.auth.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class JwtNotFoundRefreshTokenException extends CustomException {
+    public JwtNotFoundRefreshTokenException(ErrorCode errorCode) { super(errorCode); }
+
+    public JwtNotFoundRefreshTokenException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/devcv/auth/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/devcv/auth/filter/JwtAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -17,19 +18,37 @@ import java.util.HashMap;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    private final ObjectMapper objectMapper;
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-        sendResponse(response);
+        String exception = String.valueOf(request.getAttribute("exception"));
+
+        if(exception == null) {
+            log.error(ErrorCode.JWT_EXPIRED_ERROR.getMessage());
+            sendResponse(response, ErrorCode.JWT_EXPIRED_ERROR);
+        }
+        //잘못된 타입의 토큰인 경우
+        else if(exception.equals(ErrorCode.JWT_INVALID_SIGN_ERROR.getMessage())) {
+            log.error(ErrorCode.JWT_INVALID_SIGN_ERROR.getMessage());
+            sendResponse(response, ErrorCode.JWT_INVALID_SIGN_ERROR);
+        }
+        //지원되지 않는 토큰일 경우
+        else if(exception.equals(ErrorCode.JWT_UNSUPPORTED_ERROR.getMessage())) {
+            log.error(ErrorCode.JWT_UNSUPPORTED_ERROR.getMessage());
+            sendResponse(response, ErrorCode.JWT_UNSUPPORTED_ERROR);
+        }
+        else {
+            log.error(ErrorCode.JWT_EXPIRED_ERROR.getMessage());
+            sendResponse(response, ErrorCode.JWT_EXPIRED_ERROR);
+        }
     }
-    private void sendResponse(HttpServletResponse response) throws IOException {
-        response.setStatus(401);
-        response.setCharacterEncoding("utf-8");
-        response.setContentType("application/json");
-        log.error(ErrorCode.UNAUTHORIZED_ERROR.name() + " : "+ ErrorCode.UNAUTHORIZED_ERROR.getMessage());
-        response.getWriter().write(objectMapper.writeValueAsString(new HashMap<>(){{
-            put("errorCode",ErrorCode.UNAUTHORIZED_ERROR.name());
-            put("message",ErrorCode.UNAUTHORIZED_ERROR.getMessage());
-        }}));
+    private void sendResponse(HttpServletResponse response, ErrorCode exceptionCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("errorCode", exceptionCode.name());
+        responseJson.put("message", exceptionCode.getMessage());
+
+        response.getWriter().print(responseJson);
     }
 }

--- a/src/main/java/com/devcv/auth/filter/JwtFilter.java
+++ b/src/main/java/com/devcv/auth/filter/JwtFilter.java
@@ -6,6 +6,9 @@ import com.devcv.auth.jwt.JwtTokenDto;
 import com.devcv.common.exception.ErrorCode;
 import com.devcv.common.exception.UnAuthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -34,42 +37,26 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws IOException, ServletException {
         // 1. Request Header 에서 토큰 추출.
         String accessToken = jwtProvider.resolveAccessToken(request);
-        String refreshToken = jwtProvider.resolveRefreshToken(request);
         // 2. AccessToken 유/무 판별.
-        if (StringUtils.hasText(accessToken)) {
-            if(jwtProvider.validateToken(accessToken)){
-                // SpringContextHolder에 등록.
-                this.setAuthentication(accessToken);
-            // refreshToken 유/무 판별 -> 유효성 검사
-            } else if (!jwtProvider.validateToken(accessToken) && StringUtils.hasText(refreshToken)){
-                // refreshToken 유효성검사.
-                if(jwtProvider.validateToken(refreshToken)){
-                    // 검사완료되면 accessToken 재발급 jwtProvider.refreshTokenDto
-                    String email = String.valueOf(jwtProvider.parseClaims(refreshToken).get("email"));
-                    JwtTokenDto jwtTokenDto = jwtProvider.refreshTokenDto(email,refreshToken);
-                    response.setContentType("application/json");
-                    response.setCharacterEncoding("utf-8");
-                    response.setHeader("Authorization","Bearer "+jwtTokenDto.getAccessToken());
-                    Cookie refreshCookie = new Cookie("RefreshToken", refreshToken);
-                    refreshCookie.setPath("/members/refresh-token");
-                    refreshCookie.setHttpOnly(true);
-                    refreshCookie.setDomain("devcv.net");
-                    refreshCookie.setSecure(true);
-                    refreshCookie.setMaxAge(60*60);
-                    response.addCookie(refreshCookie);
-                    RefreshTokenResponse refreshTokenResponse = new RefreshTokenResponse();
-                    refreshTokenResponse.setAccessToken(jwtTokenDto.getAccessToken());
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    String resultResponse = objectMapper.writeValueAsString(refreshTokenResponse);
-                    response.getWriter().write(resultResponse);
-                    this.setAuthentication(jwtTokenDto.getAccessToken());
-                } else {
-                    throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED_ERROR);
+        try {
+            log.info("REQUEST_JWTTOKEN : " + accessToken);
+            if (StringUtils.hasText(accessToken)) {
+                if(jwtProvider.validateToken(accessToken)){
+                    // 정상 : Authentication SecurityContext에 저장. setAuthentication
+                    this.setAuthentication(accessToken);
                 }
             }
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            request.setAttribute("exception", ErrorCode.JWT_INVALID_SIGN_ERROR.getMessage());
+        } catch (ExpiredJwtException e){
+            request.setAttribute("exception", ErrorCode.JWT_EXPIRED_ERROR.getMessage());
+        } catch (UnsupportedJwtException e) {
+            request.setAttribute("exception", ErrorCode.JWT_UNSUPPORTED_ERROR.getMessage());
+        } catch (IllegalArgumentException e) {
+            request.setAttribute("exception", ErrorCode.JWT_ILLEGALARGUMENT_ERROR.getMessage());
+        } catch (Exception e) {
+            request.setAttribute("exception", ErrorCode.JWTILLEGALARG_ERROR.getMessage());
         }
-        // 2. validateToken 으로 토큰 유효성 검사
-        // 정상 : Authentication SecurityContext에 저장. setAuthentication
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/devcv/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/devcv/auth/jwt/JwtProvider.java
@@ -14,6 +14,7 @@ import com.devcv.member.repository.MemberRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -146,19 +147,9 @@ public class JwtProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.error("잘못된 JWT 서명입니다.");
-            throw new JwtInvalidSignException(ErrorCode.JWT_INVALID_SIGN_ERROR);
-        } catch (ExpiredJwtException e) {
+        }  catch (ExpiredJwtException e) {
             log.error("만료된 JWT 토큰입니다.");
             return false;
-//            throw new JwtExpiredException(ErrorCode.JWT_EXPIRED_ERROR);
-        } catch (UnsupportedJwtException e) {
-            log.error("지원되지 않는 JWT 토큰입니다.");
-            throw new JwtUnsupportedException(ErrorCode.JWT_UNSUPPORTED_ERROR);
-        } catch (IllegalArgumentException e) {
-            log.error("JWT 토큰이 잘못되었습니다.");
-            throw new JwtIllegalArgumentException(ErrorCode.JWT_ILLEGALARGUMENT_ERROR);
         }
     }
 
@@ -178,6 +169,7 @@ public class JwtProvider {
     }
     public String resolveRefreshToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_REFRESH_HEADER);
+        System.out.println(Arrays.toString(request.getCookies()));
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
             return bearerToken.split(" ")[1].trim();
         }

--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     JWT_UNSUPPORTED_ERROR("지원되지 않는 JWT 토큰입니다. 로그인 해 주세요."),
     JWT_ILLEGALARGUMENT_ERROR("잘못된 JWT 토큰입니다. 올바른 토큰을 입력해주세요."),
     JWT_INVALID_SIGN_ERROR("잘못된 JWT 서명입니다. 올바른 JWT을 등록해주세요."),
+    JWT_NOT_EXPIRED_ERROR("만료되지 않는 JWT 토큰입니다. 만료된 JWT 토큰을 담아주세요."),
     SOCIAL_ERROR("소셜 정보가 틀립니다."),
     SOCIAL_LOGIN_ERROR("이미 일반계정으로 가입되어 있습니다. 일반로그인을 진행해주세요"),
     SOCIAL_UPDATE_ERROR("소셜 비밀번호는 변경하실 수 없습니다. 소셜로그인을 진행해주세요."),
@@ -43,6 +44,7 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND("댓글을 찾을 수 없습니다"),
     RESUME_NOT_EXIST("삭제된 이력서입니다"),
     EVENT_NOT_FOUND("이벤트를 찾을 수 없습니다."),
+    REFRESHTOKEN_NOT_FOUND("RefreshToken을 찾을 수 없습니다."),
 
     //409
     CONFLICT_ERROR("요청 충돌 에러"),

--- a/src/main/java/com/devcv/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcv/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     JWT_INVALID_SIGN_ERROR("잘못된 JWT 서명입니다. 올바른 JWT을 등록해주세요."),
     JWT_NOT_EXPIRED_ERROR("만료되지 않는 JWT 토큰입니다. 만료된 JWT 토큰을 담아주세요."),
     SOCIAL_ERROR("소셜 정보가 틀립니다."),
+    MEMBERID_ERROR("요청과 맞지 않는 memberId입니다."),
     SOCIAL_LOGIN_ERROR("이미 일반계정으로 가입되어 있습니다. 일반로그인을 진행해주세요"),
     SOCIAL_UPDATE_ERROR("소셜 비밀번호는 변경하실 수 없습니다. 소셜로그인을 진행해주세요."),
     LOGIN_ERROR("아이디 혹은 비밀번호가 틀립니다."),

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.devcv.common.exception;
 
-import com.devcv.auth.exception.JwtExpiredException;
-import com.devcv.auth.exception.JwtIllegalArgumentException;
-import com.devcv.auth.exception.JwtInvalidSignException;
-import com.devcv.auth.exception.JwtUnsupportedException;
+import com.devcv.auth.exception.*;
 import com.devcv.common.exception.dto.ErrorResponse;
 import com.devcv.member.exception.*;
 import com.devcv.resume.exception.*;
@@ -118,6 +115,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ErrorResponse.from(ErrorCode.SOCIAL_LOGIN_ERROR));
     }
+    @ExceptionHandler(JwtNotExpiredException.class)
+    public ResponseEntity<ErrorResponse> handle(JwtNotExpiredException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.from(ErrorCode.JWT_NOT_EXPIRED_ERROR));
+    }
     // 401 end
 
     // 403
@@ -173,6 +176,12 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.from(ErrorCode.RESUME_NOT_EXIST));
+    }
+    @ExceptionHandler(JwtNotFoundRefreshTokenException.class)
+    public ResponseEntity<ErrorResponse> handle(JwtNotFoundRefreshTokenException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.from(ErrorCode.REFRESHTOKEN_NOT_FOUND));
     }
     // 404 end
 

--- a/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcv/common/exception/GlobalExceptionHandler.java
@@ -121,6 +121,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ErrorResponse.from(ErrorCode.JWT_NOT_EXPIRED_ERROR));
     }
+    @ExceptionHandler(NotMatchMemberIdException.class)
+    public ResponseEntity<ErrorResponse> handle(NotMatchMemberIdException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.from(ErrorCode.MEMBERID_ERROR));
+    }
     // 401 end
 
     // 403

--- a/src/main/java/com/devcv/member/exception/NotMatchMemberIdException.java
+++ b/src/main/java/com/devcv/member/exception/NotMatchMemberIdException.java
@@ -1,0 +1,10 @@
+package com.devcv.member.exception;
+
+import com.devcv.common.exception.CustomException;
+import com.devcv.common.exception.ErrorCode;
+
+public class NotMatchMemberIdException extends CustomException {
+    public NotMatchMemberIdException(ErrorCode errorCode) {super(errorCode);}
+
+    public NotMatchMemberIdException(ErrorCode errorCode, String message) {super(errorCode, message);}
+}

--- a/src/main/java/com/devcv/member/presentation/MemberController.java
+++ b/src/main/java/com/devcv/member/presentation/MemberController.java
@@ -1,6 +1,7 @@
 package com.devcv.member.presentation;
 
 import com.devcv.auth.application.AuthService;
+import com.devcv.auth.details.MemberDetails;
 import com.devcv.auth.dto.RefreshTokenResponse;
 import com.devcv.auth.exception.JwtNotExpiredException;
 import com.devcv.auth.exception.JwtNotFoundRefreshTokenException;
@@ -42,6 +43,7 @@ import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/members/*")
@@ -258,10 +260,18 @@ public class MemberController {
     @GetMapping("{member-id}")
     public ResponseEntity<MemberMypageResponse> getMember(@PathVariable("member-id") Long memberId) {
         try {
+            // 로그인한 사용자 memberId 확인
+            MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            if(!Objects.equals(memberDetails.getMember().getMemberId(), memberId)){
+                throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
+            }
             return ResponseEntity.ok().body(MemberMypageResponse.from(memberService.findMemberBymemberId(memberId)));
         } catch (NotSignUpException e){
             e.fillInStackTrace();
             throw new NotSignUpException(ErrorCode.MEMBER_NOT_FOUND);
+        } catch (NotMatchMemberIdException e){
+            e.fillInStackTrace();
+            throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
         }
     }
     @PutMapping("/{member-id}")
@@ -279,6 +289,11 @@ public class MemberController {
             throw new NotNullException(ErrorCode.NULL_ERROR);
         }
         try {
+            // 로그인한 사용자 memberId 확인
+            MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            if(!Objects.equals(memberDetails.getMember().getMemberId(), memberId)){
+                throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
+            }
             // memberId로 Member 찾기
             Member findMemberBymemberId = memberService.findMemberBymemberId(memberId);
             if(findMemberBymemberId != null){
@@ -341,6 +356,9 @@ public class MemberController {
         } catch (DuplicationException e){
             e.fillInStackTrace();
             throw new DuplicationException(ErrorCode.DUPLICATE_ERROR);
+        } catch (NotMatchMemberIdException e){
+            e.fillInStackTrace();
+            throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
         }
     }
     //----------- modi member end -----------

--- a/src/main/java/com/devcv/member/presentation/MemberController.java
+++ b/src/main/java/com/devcv/member/presentation/MemberController.java
@@ -227,6 +227,10 @@ public class MemberController {
         }
         // memberId로 찾은 멤버 패스워드 수정.
         try {
+            MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            if(!Objects.equals(memberDetails.getMember().getMemberId(), memberId)){
+                throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
+            }
             Member findMemberBymemberId = memberService.findMemberBymemberId(memberId);
             if(findMemberBymemberId != null){
                 if(!findMemberBymemberId.getSocial().name().equals(SocialType.normal.name())){
@@ -254,6 +258,9 @@ public class MemberController {
         } catch (SocialMemberUpdateException e){
             e.fillInStackTrace();
             throw new SocialMemberUpdateException(ErrorCode.SOCIAL_UPDATE_ERROR);
+        } catch (NotMatchMemberIdException e){
+            e.fillInStackTrace();
+            throw new NotMatchMemberIdException(ErrorCode.MEMBERID_ERROR);
         }
     }
     // 회원정보 단건 조회/수정


### PR DESCRIPTION
[Feat] RefreshToken Cookie에 담아 전송(#84)

## #️⃣ 연관된 이슈
> #84 
## 📝 작업 내용
1. 로그아웃 기능 구현
2. Cookie에 RefreshToken 담아 Response.
3. JWT Exception Handling 추가.
4. 회원정보수정에서 현재 로그인한 사용자말고 다른 사용자정보를 수정할 경우 Exception 추가.

### 스크린샷 (선택)
1.
<img width="788" alt="image" src="https://github.com/DevCVTeam/DevCV-backend/assets/87213815/89a8f03a-a29c-4f12-b31d-8e4bc255d032"><br>

2.
<img width="788" alt="image" src="https://github.com/DevCVTeam/DevCV-backend/assets/87213815/8adb40ce-4e93-4995-bd95-6eefe33e1712"><br>
3.
<img width="790" alt="image" src="https://github.com/DevCVTeam/DevCV-backend/assets/87213815/aa75d64c-3e3f-468b-870c-0386b9c92df7"><br>
4.
<img width="786" alt="image" src="https://github.com/DevCVTeam/DevCV-backend/assets/87213815/529390a1-4e0b-44f8-8b87-0edc1880fb3d"><br>

## 💬 리뷰 요구사항(선택)
