### PR TITLE
🎨 [Refactor] 주문 기능 리팩토링 #83

### DIFF
--- a/src/main/java/com/devcv/order/application/OrderService.java
+++ b/src/main/java/com/devcv/order/application/OrderService.java
@@ -112,20 +112,27 @@ public class OrderService {
         }
     }
 
-    public OrderResponse getOrderResponse(Long orderId, Member member) {
-        Order order = orderRepository.findOrderByOrderIdAndMember(orderId, member)
+    public OrderResponse findByOrderNumber(String orderNumber, Member member) {
+        Order order = orderRepository.findOrderByOrderNumberAndMember(orderNumber, member)
                 .orElseThrow(() -> new OrderNotFoundException(ErrorCode.ORDER_NOT_FOUND));
-        List<OrderResume> orderResumeList = orderResumeRepository.findAllByOrder_OrderId(orderId);
+        return getOrderResponse(order);
+    }
+
+    private OrderResponse getOrderResponse(Order order) {
+//        Order order = orderRepository.findOrderByOrderNumberAndMember(orderNumber, member)
+//                .orElseThrow(() -> new OrderNotFoundException(ErrorCode.ORDER_NOT_FOUND));
+        List<OrderResume> orderResumeList = orderResumeRepository.findAllByOrder_OrderId(order.getOrderId());
         return OrderResponse.of(order, orderResumeListToDto(orderResumeList));
     }
 
     private List<OrderResumeDto> orderResumeListToDto(List<OrderResume> orderResumeList) {
-        return orderResumeList.stream().map(OrderResume::getResume).map(OrderResumeDto::from).collect(Collectors.toList());
+        return orderResumeList.stream().map(OrderResume::getResume)
+                .map(OrderResumeDto::from).collect(Collectors.toList());
     }
 
     public OrderListResponse getOrderListByMember(Member member) {
         List<OrderResponse> orderList = orderRepository.findOrderListByMember(member).stream()
-                .map(order -> getOrderResponse(order.getOrderId(), member))
+                .map(this::getOrderResponse)
                 .collect(Collectors.toList());
         int count = orderList.size();
         return OrderListResponse.of(member.getMemberId(), count, orderList);

--- a/src/main/java/com/devcv/order/domain/Order.java
+++ b/src/main/java/com/devcv/order/domain/Order.java
@@ -35,24 +35,29 @@ public class Order extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private OrderStatus orderStatus;
 
+    @Column
+    private PayType payType;
+
     public Order(Long orderId, String orderNumber, Member member, Long totalPrice, List<OrderResume> orderResumeList,
-                 OrderStatus orderStatus) {
+                 OrderStatus orderStatus, PayType payType) {
         this.orderId = orderId;
         this.orderNumber = orderNumber;
         this.member = member;
         this.totalPrice = totalPrice;
         this.orderResumeList = orderResumeList;
         this.orderStatus = orderStatus;
+        this.payType = payType;
     }
 
     public void updateOrderResumeList(List<OrderResume> orderResumeList) {
         this.orderResumeList = orderResumeList;
         this.totalPrice = calculateTotalPrice(orderResumeList);
+        this.orderStatus = OrderStatus.COMPLETED;
     }
 
     public static Order init(Member member) {
         return new Order(null, OrderNumberGenerator.generateOrderNumber(), member, 0L,
-                null, OrderStatus.PENDING);
+                null, OrderStatus.PENDING, PayType.POINT);
     }
 
     private Long calculateTotalPrice(List<OrderResume> resumeList) {

--- a/src/main/java/com/devcv/order/domain/Order.java
+++ b/src/main/java/com/devcv/order/domain/Order.java
@@ -35,14 +35,6 @@ public class Order extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private OrderStatus orderStatus;
 
-//    public Order(Member member) {
-//        this.orderId = null;
-//        this.orderNumber = OrderNumberGenerator.generateOrderNumber();
-//        this.member = member;
-//        this.totalPrice = 0L;
-//        this.orderStatus = OrderStatus.PENDING;
-//    }
-
     public Order(Long orderId, String orderNumber, Member member, Long totalPrice, List<OrderResume> orderResumeList,
                  OrderStatus orderStatus) {
         this.orderId = orderId;

--- a/src/main/java/com/devcv/order/domain/Order.java
+++ b/src/main/java/com/devcv/order/domain/Order.java
@@ -2,54 +2,68 @@ package com.devcv.order.domain;
 
 import com.devcv.common.domain.BaseTimeEntity;
 import com.devcv.member.domain.Member;
-import com.devcv.resume.domain.Resume;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Getter
 @Table(name = "tb_order")
 @Builder(toBuilder = true)
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseTimeEntity {
 
     @Id
-    @Column(unique = true)
-    private String orderId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderId;
 
-    @ManyToOne
+    @Column(unique = true, nullable = false)
+    private String orderNumber;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne
-    private Resume resume;
-
     @Column
-    private int totalAmount;
+    private Long totalPrice;
 
-    @Column
-    private String sellerName;
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderResume> orderResumeList;
 
-    @Column
-    @Enumerated(value = EnumType.STRING)
-    private PayType payType;
-
-    @Column
+    @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private OrderStatus orderStatus;
 
-    public Order(Member member, Resume resume) {
-        this.orderId = OrderNumberGenerator.generateOrderNumber();
+//    public Order(Member member) {
+//        this.orderId = null;
+//        this.orderNumber = OrderNumberGenerator.generateOrderNumber();
+//        this.member = member;
+//        this.totalPrice = 0L;
+//        this.orderStatus = OrderStatus.PENDING;
+//    }
+
+    public Order(Long orderId, String orderNumber, Member member, Long totalPrice, List<OrderResume> orderResumeList,
+                 OrderStatus orderStatus) {
+        this.orderId = orderId;
+        this.orderNumber = orderNumber;
         this.member = member;
-        this.resume = resume;
-        this.totalAmount = resume.getPrice();
-        this.sellerName = resume.getMember().getMemberName();
-        this.payType = PayType.POINT;
-        this.orderStatus = OrderStatus.CREATED;
+        this.totalPrice = totalPrice;
+        this.orderResumeList = orderResumeList;
+        this.orderStatus = orderStatus;
     }
 
-    public static Order of(Member member, Resume resume) {
-        // 검증?
-        return new Order(member, resume);
+    public void updateOrderResumeList(List<OrderResume> orderResumeList) {
+        this.orderResumeList = orderResumeList;
+        this.totalPrice = calculateTotalPrice(orderResumeList);
+    }
+
+    public static Order init(Member member) {
+        return new Order(null, OrderNumberGenerator.generateOrderNumber(), member, 0L,
+                null, OrderStatus.PENDING);
+    }
+
+    private Long calculateTotalPrice(List<OrderResume> resumeList) {
+        return resumeList.stream().mapToLong(OrderResume::getPrice).sum();
     }
 }

--- a/src/main/java/com/devcv/order/domain/OrderResume.java
+++ b/src/main/java/com/devcv/order/domain/OrderResume.java
@@ -1,0 +1,45 @@
+package com.devcv.order.domain;
+
+import com.devcv.resume.domain.Resume;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "tb_order_resume")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderResume {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderResumeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Column(nullable = false)
+    private Long price;
+
+    public OrderResume(Long orderResumeId, Order order, Resume resume, Long price) {
+        this.orderResumeId = orderResumeId;
+        this.order = order;
+        this.resume = resume;
+        this.price = price;
+    }
+
+    //    public OrderResume(Order order, Resume resume, Long price) {
+//        this.orderResumeId = null;
+//        this.order = order;
+//        this.resume = resume;
+//        this.price = price;
+//    }
+
+    public static OrderResume of(Order order, Resume resume) {
+        return new OrderResume(null, order, resume, (long) resume.getPrice());
+    }
+}

--- a/src/main/java/com/devcv/order/domain/OrderStatus.java
+++ b/src/main/java/com/devcv/order/domain/OrderStatus.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 @Getter
 public enum OrderStatus {
 
-    CREATED("주문생성완료"),
-    PENDING_PAYMENT("결제대기"),
-    COMPLETED("구매완료");
+    PENDING("결제대기"),
+    COMPLETED("결제완료"),
+    CANCELLED("취소");
 
     private final String status;
 

--- a/src/main/java/com/devcv/order/domain/dto/CartDto.java
+++ b/src/main/java/com/devcv/order/domain/dto/CartDto.java
@@ -1,5 +1,7 @@
 package com.devcv.order.domain.dto;
 
-public record CartDto(Long resumeId, Long price) {
+import jakarta.validation.constraints.NotNull;
+
+public record CartDto(@NotNull Long resumeId, @NotNull Long price) {
 
 }

--- a/src/main/java/com/devcv/order/domain/dto/CartDto.java
+++ b/src/main/java/com/devcv/order/domain/dto/CartDto.java
@@ -1,0 +1,5 @@
+package com.devcv.order.domain.dto;
+
+public record CartDto(Long resumeId, Long price) {
+
+}

--- a/src/main/java/com/devcv/order/domain/dto/CartOrderRequest.java
+++ b/src/main/java/com/devcv/order/domain/dto/CartOrderRequest.java
@@ -1,7 +1,13 @@
 package com.devcv.order.domain.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 
-public record CartOrderRequest(int resumeCount, Long totalPrice, List<CartDto> cartList) {
+public record CartOrderRequest(@Min(value = 1, message = "이력서 개수가 1보다 작습니다.") int resumeCount,
+                               @NotNull Long totalPrice,
+                               @NotNull @Valid List<CartDto> cartList) {
 
 }

--- a/src/main/java/com/devcv/order/domain/dto/CartOrderRequest.java
+++ b/src/main/java/com/devcv/order/domain/dto/CartOrderRequest.java
@@ -1,0 +1,7 @@
+package com.devcv.order.domain.dto;
+
+import java.util.List;
+
+public record CartOrderRequest(int resumeCount, Long totalPrice, List<CartDto> cartList) {
+
+}

--- a/src/main/java/com/devcv/order/domain/dto/OrderListResponse.java
+++ b/src/main/java/com/devcv/order/domain/dto/OrderListResponse.java
@@ -2,9 +2,9 @@ package com.devcv.order.domain.dto;
 
 import java.util.List;
 
-public record OrderListResponse(Long memberId, int count, List<OrderResponse> orderList) {
+public record OrderListResponse(Long memberId, int orderCount, List<OrderResponse> orderList) {
 
-    public static OrderListResponse of(Long memberId, int count, List<OrderResponse> orderList) {
-        return new OrderListResponse(memberId, count, orderList);
+    public static OrderListResponse of(Long memberId, int orderCount, List<OrderResponse> orderList) {
+        return new OrderListResponse(memberId, orderCount, orderList);
     }
 }

--- a/src/main/java/com/devcv/order/domain/dto/OrderResponse.java
+++ b/src/main/java/com/devcv/order/domain/dto/OrderResponse.java
@@ -2,27 +2,23 @@ package com.devcv.order.domain.dto;
 
 import com.devcv.order.domain.Order;
 import com.devcv.order.domain.OrderStatus;
-import com.devcv.order.domain.PayType;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
-public record OrderResponse(String orderId,
-                            String resumeTitle,
-                            int totalAmount,
+public record OrderResponse(Long orderId,
+                            Long totalPrice,
                             OrderStatus orderStatus,
                             LocalDateTime createdDate,
-                            PayType payType,
-                            String sellerName) {
+                            List<OrderResumeDto> orderResumeDtoList) {
 
-    public static OrderResponse from(Order order) {
+    public static OrderResponse of(Order order, List<OrderResumeDto> orderResumeDtoList) {
         return new OrderResponse(
                 order.getOrderId(),
-                order.getResume().getTitle(),
-                order.getTotalAmount(),
+                order.getTotalPrice(),
                 order.getOrderStatus(),
                 order.getCreatedDate(),
-                order.getPayType(),
-                order.getSellerName());
+                orderResumeDtoList);
     }
 }

--- a/src/main/java/com/devcv/order/domain/dto/OrderResponse.java
+++ b/src/main/java/com/devcv/order/domain/dto/OrderResponse.java
@@ -7,15 +7,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 
-public record OrderResponse(Long orderId,
+public record OrderResponse(String orderNumber,
                             Long totalPrice,
                             OrderStatus orderStatus,
                             LocalDateTime createdDate,
-                            List<OrderResumeDto> orderResumeDtoList) {
+                            List<OrderResumeDto> orderList) {
 
     public static OrderResponse of(Order order, List<OrderResumeDto> orderResumeDtoList) {
         return new OrderResponse(
-                order.getOrderId(),
+                order.getOrderNumber(),
                 order.getTotalPrice(),
                 order.getOrderStatus(),
                 order.getCreatedDate(),

--- a/src/main/java/com/devcv/order/domain/dto/OrderResumeDto.java
+++ b/src/main/java/com/devcv/order/domain/dto/OrderResumeDto.java
@@ -1,0 +1,14 @@
+package com.devcv.order.domain.dto;
+
+import com.devcv.resume.domain.Resume;
+
+public record OrderResumeDto(Long resumeId, String title, Long price, String resumeFilePath) {
+
+    public static OrderResumeDto from(Resume resume) {
+        return new OrderResumeDto(
+                resume.getResumeId(),
+                resume.getTitle(),
+                (long) resume.getPrice(),
+                resume.getResumeFilePath());
+    }
+}

--- a/src/main/java/com/devcv/order/presentation/OrderController.java
+++ b/src/main/java/com/devcv/order/presentation/OrderController.java
@@ -42,11 +42,11 @@ public class OrderController {
         return ResponseEntity.created(URI.create(String.valueOf(order.getOrderId()))).build();
     }
 
-    @GetMapping("/orders/{order-id}")
+    @GetMapping("/orders/{order-number}")
     public ResponseEntity<OrderResponse> getOrderResponse(@AuthenticationPrincipal UserDetails userDetails,
-                                                          @PathVariable("order-id") Long orderId) {
+                                                          @PathVariable("order-number") String orderNumber) {
         Member member = extractMember(userDetails);
-        OrderResponse response = orderService.getOrderResponse(orderId, member);
+        OrderResponse response = orderService.findByOrderNumber(orderNumber, member);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/devcv/order/presentation/OrderController.java
+++ b/src/main/java/com/devcv/order/presentation/OrderController.java
@@ -6,10 +6,7 @@ import com.devcv.member.application.MemberService;
 import com.devcv.member.domain.Member;
 import com.devcv.order.application.OrderService;
 import com.devcv.order.domain.Order;
-import com.devcv.order.domain.dto.OrderListResponse;
-import com.devcv.order.domain.dto.OrderRequest;
-import com.devcv.order.domain.dto.OrderResponse;
-import com.devcv.order.domain.dto.OrderSheet;
+import com.devcv.order.domain.dto.*;
 import com.devcv.resume.application.ResumeService;
 import com.devcv.resume.domain.Resume;
 import lombok.RequiredArgsConstructor;
@@ -38,19 +35,18 @@ public class OrderController {
 
     @PostMapping("/orders")
     public ResponseEntity<Void> createOrder(@AuthenticationPrincipal UserDetails userDetails,
-                                            @RequestBody OrderRequest orderRequest) {
+                                            @RequestBody CartOrderRequest cartOrderRequest) {
         Member member = extractMember(userDetails);
-        Resume resume = resumeService.findByResumeId(orderRequest.resumeId());
-
-        Order order = orderService.createOrder(member, resume, orderRequest);
-        return ResponseEntity.created(URI.create(order.getOrderId())).build();
+        Order order = orderService.createOrder(member, cartOrderRequest);
+        return ResponseEntity.created(URI.create(String.valueOf(order.getOrderId()))).build();
     }
 
     @GetMapping("/orders/{order-id}")
     public ResponseEntity<OrderResponse> getOrderResponse(@AuthenticationPrincipal UserDetails userDetails,
-                                                          @PathVariable("order-id") String orderId) {
+                                                          @PathVariable("order-id") Long orderId) {
         Member member = extractMember(userDetails);
-        return ResponseEntity.ok().body(OrderResponse.from(orderService.getOrderByIdAndMember(orderId, member)));
+        OrderResponse response = orderService.getOrderResponse(orderId, member);
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/members/{member-id}/orders")

--- a/src/main/java/com/devcv/order/presentation/OrderController.java
+++ b/src/main/java/com/devcv/order/presentation/OrderController.java
@@ -9,6 +9,7 @@ import com.devcv.order.domain.Order;
 import com.devcv.order.domain.dto.*;
 import com.devcv.resume.application.ResumeService;
 import com.devcv.resume.domain.Resume;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,7 +36,7 @@ public class OrderController {
 
     @PostMapping("/orders")
     public ResponseEntity<Void> createOrder(@AuthenticationPrincipal UserDetails userDetails,
-                                            @RequestBody CartOrderRequest cartOrderRequest) {
+                                            @RequestBody @Valid CartOrderRequest cartOrderRequest) {
         Member member = extractMember(userDetails);
         Order order = orderService.createOrder(member, cartOrderRequest);
         return ResponseEntity.created(URI.create(String.valueOf(order.getOrderId()))).build();

--- a/src/main/java/com/devcv/order/repository/OrderRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, String> {
 
-    Optional<Order> findOrderByOrderIdAndMember(Long orderId, Member member);
+    Optional<Order> findOrderByOrderNumberAndMember(String orderNumber, Member member);
 
     // 주문id 조회
     @Query("SELECT o FROM Order o " +

--- a/src/main/java/com/devcv/order/repository/OrderRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderRepository.java
@@ -4,16 +4,20 @@ import com.devcv.member.domain.Member;
 import com.devcv.order.domain.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, String> {
 
-    Optional<Order> findOrderByOrderIdAndMember(String orderId, Member member);
+    Optional<Order> findOrderByOrderIdAndMember(Long orderId, Member member);
 
     // 주문id 조회
-    Optional<Order> findByMember_MemberIdAndResume_ResumeId(Long memberId, Long resumeId);
-  
+    @Query("SELECT o FROM Order o " +
+            "JOIN o.orderResumeList r " +
+            "WHERE o.member.memberId = :memberId AND r.orderResumeId = :resumeId")
+    Optional<Order> findByMemberIdAndResumeId(@Param("memberId") Long memberId, @Param("resumeId") Long resumeId);
+
     List<Order> findOrderListByMember(Member member);
 }

--- a/src/main/java/com/devcv/order/repository/OrderRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderRepository.java
@@ -20,4 +20,7 @@ public interface OrderRepository extends JpaRepository<Order, String> {
     Optional<Order> findByMemberIdAndResumeId(@Param("memberId") Long memberId, @Param("resumeId") Long resumeId);
 
     List<Order> findOrderListByMember(Member member);
+
+    @Query("SELECT orderResume.resume.resumeId FROM OrderResume orderResume INNER JOIN orderResume.order o WHERE o.member.memberId = :memberId")
+    List<Long> getResumeIdsByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/devcv/order/repository/OrderResumeRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderResumeRepository.java
@@ -1,0 +1,13 @@
+package com.devcv.order.repository;
+
+import com.devcv.order.domain.OrderResume;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderResumeRepository extends JpaRepository<OrderResume, Long> {
+
+    @EntityGraph(attributePaths = {"resume"}, type=EntityGraph.EntityGraphType.FETCH)
+    List<OrderResume> findAllByOrder_OrderId(Long orderId);
+}

--- a/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
@@ -112,7 +112,7 @@ public class ReviewServiceImpl implements  ReviewService{
     public Review register(Long resumeId, Long memberId, ReviewDto resumeReviewDto) {
 
         // 주문여부 확인
-        Optional<Order> orderIdOpt = orderRepository. findByMember_MemberIdAndResume_ResumeId(memberId, resumeId);
+        Optional<Order> orderIdOpt = orderRepository.findByMemberIdAndResumeId(memberId, resumeId);
         if (orderIdOpt.isEmpty()) {
             throw new OrderNotFoundException(ErrorCode.ORDER_NOT_FOUND);
         }
@@ -126,7 +126,7 @@ public class ReviewServiceImpl implements  ReviewService{
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-        String orderId = orderIdOpt.get().getOrderId();
+        Long orderId = orderIdOpt.get().getOrderId();
         resumeReviewDto.setResumeId(resumeId);
         resumeReviewDto.setMemberId(memberId);
         resumeReviewDto.setOrderId(orderId);

--- a/src/main/java/com/devcv/review/domain/dto/ReviewDto.java
+++ b/src/main/java/com/devcv/review/domain/dto/ReviewDto.java
@@ -23,7 +23,7 @@ public class ReviewDto {
     private Long memberId;
     private String reviewerNickname;
 
-    private String orderId;
+    private Long orderId;
 
     private int grade;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#83 
## 📝 작업 내용

다중 구매 가능하도록 로직을 변경하면서 엔티티와 Dto, 예외처리를 추가했습니다.

- 장바구니 대응(주문 전 임시 dto, 다중 주문 고려)
- entity table 변경
- request, reponse 변경
- 주문과 이력서의 중간 테이블 생성
- 컨트롤러, 서비스 로직 수정
- resume별로 예외처리를 하도록 변경
- 중복 예외 제거
- request에서 유효성검사 하도록 변경
- dto의 total price와 dto내부의 dto들의 Price를 합친 값 비교
- DTO의 이력서 가격과 DB 저장된 이력서의 값이 일치하는지 비교
- 보유포인트 검증
- Long orderId 대신 String orderNumber를 이용해 주문 조회하도록 로직 수정
- response도 orderNumber를 반환하도록 수정




기능별 바뀐점 요약
- 주문생성(예외처리 추가, 다중 구매 기능, requestBody 변경)
- 주문조회(주문번호로 조회할 수 있도록 엔드포인트 변경, responseBody 변경)
- 멤버별 주문조회(responseBody 변경)


### 스크린샷 (선택)
![스크린샷 2024-06-28 오전 3 15 13](https://github.com/DevCVTeam/DevCV-backend/assets/143480682/a9868879-c687-44d1-b846-5497f2aaf1da)
![스크린샷 2024-06-28 오전 3 15 25](https://github.com/DevCVTeam/DevCV-backend/assets/143480682/603452bc-0702-47ab-a7d2-407e2498887d)
![스크린샷 2024-06-28 오전 3 15 36](https://github.com/DevCVTeam/DevCV-backend/assets/143480682/5b2f6baa-f9a5-4c8b-a52a-0c38274f55b9)

## 💬 리뷰 요구사항(선택)

