### PR TITLE
🎨 [Refactor] 이력서 판매내역 조회 시 삭제 이력서 제외, dtoToEntity 파라미터 order 엔티티 객체로 수정

### DIFF
--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -26,7 +26,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -120,17 +119,6 @@ public class ResumeServiceImpl implements ResumeService {
         return entityToDto(resume, averageGrade, reviewCount, false);
     }
 
-    // 회원별 이력서 조회
-
-    @Override
-    public ResumeListResponse findResumesByMemberId(Long memberId) {
-        List<ResumeResponse> resumeList = resumeRepository.findByMember(memberId).
-                stream()
-                .map(ResumeResponse::from)
-                .collect(Collectors.toList());;
-        return ResumeListResponse.of(memberId,resumeList.size(),resumeList);
-    }
-
     // 이력서 등록(승인대기)
     @Override
     public Resume register(ResumeRequest resumeRequest, MultipartFile resumeFile, List<MultipartFile> images, Long memberId) {
@@ -198,6 +186,16 @@ public class ResumeServiceImpl implements ResumeService {
 
         return resumeRepository.save(resume);
 
+    }
+
+    // 회원별 이력서 조회
+    @Override
+    public ResumeListResponse findResumesByMemberId(Long memberId) {
+        List<ResumeResponse> resumeList = resumeRepository.findByMember(memberId).
+                stream()
+                .map(ResumeResponse::from)
+                .collect(Collectors.toList());;
+        return ResumeListResponse.of(memberId,resumeList.size(),resumeList);
     }
 
     // 이력서 판매내역 상세조회

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -33,8 +33,9 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     Page<Object[]> findByStatus(ResumeStatus status, Pageable pageable);
 
     // 회원별 이력서 조회
-    @Query("SELECT rm FROM Resume rm WHERE rm.member.memberId=:memberId")
+    @Query("SELECT rm FROM Resume rm WHERE rm.member.memberId = :memberId AND rm.delFlag = false")
     List<Resume> findByMember(Long memberId);
+
     // 직무 & 회사별 이력서 조회
     @Query("SELECT rm, AVG(COALESCE(rv.grade, 0)), COUNT(rv) " +
             "FROM Resume rm LEFT JOIN Review rv ON rv.resume = rm " +

--- a/src/main/java/com/devcv/review/application/ReviewService.java
+++ b/src/main/java/com/devcv/review/application/ReviewService.java
@@ -29,13 +29,13 @@ public interface ReviewService {
     // 이력서 구매후기 삭제
     void deleteReview(Long resumeId, Long memberId, Long reviewId);
 
-    default Review dtoToEntity(ReviewDto resumeReviewDto, Resume resume, Member member) {
+    default Review dtoToEntity(ReviewDto resumeReviewDto, Resume resume, Member member, Order order) {
 
         Review resumeReview = Review.builder()
                 .reviewId(resumeReviewDto.getReviewId())
                 .resume(resume)
                 .member(member)
-                .order(Order.builder().orderId(resumeReviewDto.getOrderId()).build())
+                .order(order)
                 .grade(resumeReviewDto.getGrade())
                 .text(resumeReviewDto.getText())
                 .reviewerNickname(member.getNickName())

--- a/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
@@ -125,8 +125,8 @@ public class ReviewServiceImpl implements  ReviewService{
         }
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-
-        String orderId = orderIdOpt.get().getOrderId();
+        Order order = orderIdOpt.get();
+        String orderId = order.getOrderId();
         resumeReviewDto.setResumeId(resumeId);
         resumeReviewDto.setMemberId(memberId);
         resumeReviewDto.setOrderId(orderId);
@@ -136,7 +136,7 @@ public class ReviewServiceImpl implements  ReviewService{
             throw new AlreadyExistsException(ErrorCode.ALREADY_EXISTS);
         }
 
-        Review resumeReview = dtoToEntity(resumeReviewDto, resume, member);
+        Review resumeReview = dtoToEntity(resumeReviewDto, resume, member, order);
 
         reviewRepository.save(resumeReview);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#73 #90 

## 📝 작업 내용
1. 이력서 판매 리스트 조회 시 "삭제" 상태 이력서 제외(#73 
2. 명확한 도메인 모델링을 위한 Review 객체 변환 시 파라미터 값 기존 orderId -> order 엔티티 객체로 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
