### PR TITLE
🐛 [Fix] 주문 예외 로직 수정 #102

### DIFF
--- a/src/main/java/com/devcv/order/application/OrderService.java
+++ b/src/main/java/com/devcv/order/application/OrderService.java
@@ -84,7 +84,7 @@ public class OrderService {
     }
 
     private void checkResumeStatus(Resume resume) {
-        if (!resume.getStatus().equals(ResumeStatus.approved)) {
+        if (!resume.getStatus().equals(ResumeStatus.regcompleted)) {
             throw new BadRequestException(ErrorCode.RESUME_STATUS_EXCEPTION);
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#102 
## 📝 작업 내용
이력서 상태가 `regcompleted`인 경우에만 주문이 가능하도록 예외 로직을 수정하였습니다.