### PR TITLE
🐛 [Fix] 구매후기 등록 에러사항 수정

### DIFF
--- a/src/main/java/com/devcv/order/repository/OrderRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderRepository.java
@@ -13,12 +13,6 @@ public interface OrderRepository extends JpaRepository<Order, String> {
 
     Optional<Order> findOrderByOrderNumberAndMember(String orderNumber, Member member);
 
-    // 주문id 조회
-    @Query("SELECT o FROM Order o " +
-            "JOIN o.orderResumeList r " +
-            "WHERE o.member.memberId = :memberId AND r.orderResumeId = :resumeId")
-    Optional<Order> findByMemberIdAndResumeId(@Param("memberId") Long memberId, @Param("resumeId") Long resumeId);
-
     List<Order> findOrderListByMember(Member member);
 
     @Query("SELECT orderResume.resume.resumeId FROM OrderResume orderResume INNER JOIN orderResume.order o WHERE o.member.memberId = :memberId")

--- a/src/main/java/com/devcv/order/repository/OrderResumeRepository.java
+++ b/src/main/java/com/devcv/order/repository/OrderResumeRepository.java
@@ -11,4 +11,11 @@ public interface OrderResumeRepository extends JpaRepository<OrderResume, Long> 
 
     @Query("SELECT o FROM OrderResume o JOIN FETCH o.resume i JOIN FETCH i.imageList WHERE o.order.orderId = :orderId")
     List<OrderResume> findAllByOrder_OrderId(@Param("orderId") Long orderId);
+
+
+    // 주문id 조회
+    @Query("SELECT r FROM OrderResume r " +
+            "JOIN r.order o " +
+            "WHERE o.member.memberId = :memberId AND r.resume.resumeId = :resumeId")
+    List<OrderResume> findByMemberIdAndResumeId(@Param("memberId") Long memberId, @Param("resumeId") Long resumeId);
 }

--- a/src/main/java/com/devcv/review/application/ReviewService.java
+++ b/src/main/java/com/devcv/review/application/ReviewService.java
@@ -29,7 +29,7 @@ public interface ReviewService {
     // 이력서 구매후기 삭제
     void deleteReview(Long resumeId, Long memberId, Long reviewId);
 
-    default Review dtoToEntity(ReviewDto resumeReviewDto, Resume resume, Member member, Order order) {
+    default Review dtoToEntity(ReviewDto resumeReviewDto, Resume resume, Member member,Order order) {
 
         Review resumeReview = Review.builder()
                 .reviewId(resumeReviewDto.getReviewId())

--- a/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/devcv/review/application/ReviewServiceImpl.java
@@ -5,8 +5,10 @@ import com.devcv.common.exception.UnAuthorizedException;
 import com.devcv.member.domain.Member;
 import com.devcv.member.repository.MemberRepository;
 import com.devcv.order.domain.Order;
+import com.devcv.order.domain.OrderResume;
 import com.devcv.order.exception.OrderNotFoundException;
 import com.devcv.order.repository.OrderRepository;
+import com.devcv.order.repository.OrderResumeRepository;
 import com.devcv.resume.domain.Resume;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.exception.MemberNotFoundException;
@@ -43,6 +45,7 @@ public class ReviewServiceImpl implements  ReviewService{
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
     private final OrderRepository orderRepository;
+    private final OrderResumeRepository orderResumeRepository;
     private final CommentRepository commentRepository;
 
     private final CommentService commentService;
@@ -112,8 +115,8 @@ public class ReviewServiceImpl implements  ReviewService{
     public Review register(Long resumeId, Long memberId, ReviewDto resumeReviewDto) {
 
         // 주문여부 확인
-        Optional<Order> orderIdOpt = orderRepository.findByMemberIdAndResumeId(memberId, resumeId);
-        if (orderIdOpt.isEmpty()) {
+        List<OrderResume> orderResumes = orderResumeRepository.findByMemberIdAndResumeId(memberId, resumeId);
+        if (orderResumes.isEmpty()) {
             throw new OrderNotFoundException(ErrorCode.ORDER_NOT_FOUND);
         }
 
@@ -125,8 +128,8 @@ public class ReviewServiceImpl implements  ReviewService{
         }
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-        Order order = orderIdOpt.get();
-        Long orderId = orderIdOpt.get().getOrderId();
+        Order order = orderResumes.get(0).getOrder();
+        Long orderId = order.getOrderId();
         resumeReviewDto.setResumeId(resumeId);
         resumeReviewDto.setMemberId(memberId);
         resumeReviewDto.setOrderId(orderId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#109 

## 📝 작업 내용
1. 기존 orderRepository에 있던 주문 id 조회 쿼리 -> orderResumeRepository로 이동 

2. memberId와 resumeId를 가진 OrderResume에서 Order 정보를 가져와 orderId를 추출

3. List로 반환된 orderResume 중 0번째를 order 객체로 저장 및 orderId dto 저장

### 스크린샷 (선택)
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/7567984d-604e-4960-a499-0c7a4b4ebed6)
![image](https://github.com/DevCVTeam/DevCV-backend/assets/108069902/1ae4ee39-709f-4e5b-8353-cf15e07f4a62)
-> 다음과 같이 동일한 resume_id가  존재해도 정상적인 등록이 가능합니다!

## 💬 리뷰 요구사항(선택)
