### PR TITLE
✨ [Feat] 구글 사이트맵 등록 위한 조회 api 추가 (#127)

### DIFF
--- a/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
+++ b/src/main/java/com/devcv/auth/config/SpringSecurityConfig.java
@@ -57,7 +57,7 @@ public class SpringSecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers("/members/login","/members/signup","/members/find-id","/members/cert-email","/members/duplication-email",
                         "/members/find-pw/email","/members/find-pw","/members/{member-id}/password","/admin/login","/members/refresh-token",
-                         "/members/kakao-login","/members/google-login","/resumes","/resumes/{resume-id}", "/resumes/{resume-id}/reviews").permitAll()
+                         "/members/kakao-login","/members/google-login","/resumes/sitemap","/resumes","/resumes/{resume-id}", "/resumes/{resume-id}/reviews").permitAll()
 //                .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .requestMatchers("/admin/**").hasRole(RoleType.admin.name()) // 관리자 페이지
                 .anyRequest().authenticated()   // 이외 인증필요 -> Header에 "Bearer {accessToken}" 형태로 요청

--- a/src/main/java/com/devcv/resume/application/ResumeService.java
+++ b/src/main/java/com/devcv/resume/application/ResumeService.java
@@ -1,10 +1,7 @@
 package com.devcv.resume.application;
 
 import com.devcv.resume.domain.Resume;
-import com.devcv.resume.domain.dto.PaginatedResumeResponse;
-import com.devcv.resume.domain.dto.ResumeDto;
-import com.devcv.resume.domain.dto.ResumeListResponse;
-import com.devcv.resume.domain.dto.ResumeRequest;
+import com.devcv.resume.domain.dto.*;
 import com.devcv.resume.domain.enumtype.CompanyType;
 import com.devcv.resume.domain.enumtype.StackType;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +14,8 @@ import java.util.List;
 public interface ResumeService {
     // 이력서 목록 조회
     PaginatedResumeResponse findResumes(StackType stackType, CompanyType companyType, int page, int size);
+    // 사이트맵 등록용 목록 조회
+    List<ResumeSitemapDto> getResumeIdsAndCreationDates();
     // 이력서 상세 조회
     ResumeDto getResumeDetail(Long resumeId);
     // 회원별 이력서 조회

--- a/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
+++ b/src/main/java/com/devcv/resume/application/ResumeServiceImpl.java
@@ -57,6 +57,14 @@ public class ResumeServiceImpl implements ResumeService {
         return createPaginatedResumeResponse(resumePage, resumeDTOs);
     }
 
+    @Override
+    public List<ResumeSitemapDto> getResumeIdsAndCreationDates() {
+        List<Resume> resumes = resumeRepository.findAllByStatus(ResumeStatus.regcompleted);
+        return resumes.stream()
+                .map(resume -> new ResumeSitemapDto(resume.getResumeId(), resume.getCreatedDate()))
+                .collect(Collectors.toList());
+    }
+
 
     // 이력서 상세 조회
     @Override

--- a/src/main/java/com/devcv/resume/domain/dto/ResumeSitemapDto.java
+++ b/src/main/java/com/devcv/resume/domain/dto/ResumeSitemapDto.java
@@ -1,0 +1,15 @@
+package com.devcv.resume.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResumeSitemapDto {
+    private Long resumeId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/devcv/resume/presentation/ResumeController.java
+++ b/src/main/java/com/devcv/resume/presentation/ResumeController.java
@@ -5,10 +5,7 @@ import com.devcv.common.exception.InternalServerException;
 import com.devcv.common.exception.UnAuthorizedException;
 import com.devcv.resume.application.ResumeService;
 import com.devcv.resume.domain.Resume;
-import com.devcv.resume.domain.dto.PaginatedResumeResponse;
-import com.devcv.resume.domain.dto.ResumeDto;
-import com.devcv.resume.domain.dto.ResumeListResponse;
-import com.devcv.resume.domain.dto.ResumeRequest;
+import com.devcv.resume.domain.dto.*;
 import com.devcv.resume.domain.enumtype.CompanyType;
 import com.devcv.resume.domain.enumtype.ResumeStatus;
 import com.devcv.resume.domain.enumtype.StackType;
@@ -46,6 +43,18 @@ public class ResumeController {
         }
     }
     //------------이력서 목록 조회 요청 end---------------
+
+    //------------이력서 ID와 생성일자 조회 요청 start---------------
+    @GetMapping("/resumes/sitemap")
+    public ResponseEntity<List<ResumeSitemapDto>> getResumeIdsAndCreationDates() {
+        try {
+            List<ResumeSitemapDto> response = resumeService.getResumeIdsAndCreationDates();
+            return ResponseEntity.ok(response);
+        } catch (InternalServerException e) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+    //------------이력서 ID와 생성일자 조회 요청 end---------------
 
 
     //------------이력서 상세 조회 요청 start--------------

--- a/src/main/java/com/devcv/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/devcv/resume/repository/ResumeRepository.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
+    List<Resume> findAllByStatus(ResumeStatus status);
+
     // 판매내역 이력서 상세 조회
     @Query("SELECT r FROM Resume r WHERE r.resumeId = :resumeId AND r.member.memberId = :memberId")
     Optional<Resume> findByIdAndMemberId(Long resumeId, Long memberId);
@@ -65,6 +67,10 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     List<Object[]> findByIdAndStatus(Long resumeId);
 
     //----------------등록완료 default인 메서드 start-----------------
+
+    default List<Resume> findAllByStatus() {
+        return findAllByStatus(ResumeStatus.regcompleted);
+    }
     default Page<Object[]> findApprovedResumes(Pageable pageable) {
         return findByStatus(ResumeStatus.regcompleted, pageable);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#127 

## 📝 작업 내용
1. auth > securityconfig에 "resumes/sitemap" permitAll 추가
2. "regcompleted" 상태의 이력서를 가져오는 findAllByStatus 메서드 추가
3. resumeId, createdAt 데이터 값 조회 기능 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

확인하시는대로 바로 merge 진행해서 서버에 반영하면 좋을 것 같습니다~!