### PR TITLE
🐛 [Fix] 결제페이지에 누락된 이력서 썸네일 주소 추가. (#130)

### DIFF
--- a/src/main/java/com/devcv/order/domain/dto/OrderSheetResume.java
+++ b/src/main/java/com/devcv/order/domain/dto/OrderSheetResume.java
@@ -6,10 +6,11 @@ import com.devcv.resume.domain.enumtype.StackType;
 import java.time.LocalDateTime;
 
 public record OrderSheetResume(String title, String sellerName, int price, StackType stackType,
-                               LocalDateTime updatedDate) {
+                               LocalDateTime updatedDate, String thumbnailPath) {
 
     public static OrderSheetResume from(Resume resume) {
         return new OrderSheetResume(resume.getTitle(), resume.getMember().getNickName(), resume.getPrice(),
-                resume.getCategory().getStackType(), resume.getUpdatedDate());
+                resume.getCategory().getStackType(), resume.getUpdatedDate(),
+                resume.getImageList().get(0).getResumeImgPath());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#130 

## 📝 작업 내용
Response에 누락된 썸네일 주소 필드를 추가하였습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
